### PR TITLE
Added event emit when slashes can't be performed

### DIFF
--- a/src/middleware/Middleware.sol
+++ b/src/middleware/Middleware.sol
@@ -14,8 +14,6 @@
 // along with Tanssi.  If not, see <http://www.gnu.org/licenses/>
 pragma solidity 0.8.25;
 
-import {console2} from "forge-std/console2.sol";
-
 //**************************************************************************************************
 //                                      OPENZEPPELIN
 //**************************************************************************************************
@@ -50,6 +48,8 @@ contract Middleware is SimpleKeyRegistry32, Ownable {
     using EnumerableMap for EnumerableMap.AddressToUintMap;
     using MapWithTimeData for EnumerableMap.AddressToUintMap;
     using Subnetwork for address;
+
+    event InvalidSlashTimeframe(uint48 indexed epoch, address indexed operator, uint256 indexed amount);
 
     error Middleware__NotOperator();
     error Middleware__NotVault();
@@ -384,6 +384,14 @@ contract Middleware is SimpleKeyRegistry32, Ownable {
                 continue;
             }
 
+            if (
+                params.epochStartTs < Time.timestamp() - IVault(vault).epochDuration()
+                    || params.epochStartTs >= Time.timestamp()
+            ) {
+                emit InvalidSlashTimeframe(epoch, operator, amount);
+                return;
+            }
+
             _processVaultSlashing(vault, params);
         }
     }
@@ -401,6 +409,7 @@ contract Middleware is SimpleKeyRegistry32, Ownable {
                 subnetwork, params.operator, params.epochStartTs, new bytes(0)
             );
             uint256 slashAmount = (params.slashAmount * vaultStake) / params.totalOperatorStake;
+
             _slashVault(params.epochStartTs, vault, subnetwork, params.operator, slashAmount);
         }
     }


### PR DESCRIPTION
This PR add:
- [ ] emit an event called `InvalidSlashTimeframe(uint48 indexed epoch, address indexed operator, uint256 indexed amount)` when slash can't be performed since we are not in between a slashing period