### PR TITLE
Fixed middleware not approving for token transfer

### DIFF
--- a/src/contracts/middleware/Middleware.sol
+++ b/src/contracts/middleware/Middleware.sol
@@ -21,6 +21,7 @@ import {Time} from "@openzeppelin/contracts/utils/types/Time.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {EnumerableMap} from "@openzeppelin/contracts/utils/structs/EnumerableMap.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 //**************************************************************************************************
 //                                      SYMBIOTIC
@@ -351,6 +352,12 @@ contract Middleware is SimpleKeyRegistry32, Ownable, IMiddleware {
         bytes32 rewardsRoot,
         address tokenAddress
     ) external onlyGateway onlyIfOperatorRewardSet {
+        if (IERC20(tokenAddress).balanceOf(address(this)) < tokensInflatedToken) {
+            revert Middleware__InsufficientBalance();
+        }
+
+        IERC20(tokenAddress).approve(s_operatorRewards, tokensInflatedToken);
+
         IODefaultOperatorRewards(s_operatorRewards).distributeRewards(
             uint48(epoch), uint48(eraIndex), tokensInflatedToken, totalPointsToken, rewardsRoot, tokenAddress
         );

--- a/src/interfaces/middleware/IMiddleware.sol
+++ b/src/interfaces/middleware/IMiddleware.sol
@@ -46,9 +46,10 @@ interface IMiddleware {
     error Middleware__InvalidSubnetworksCnt();
     error Middleware__TooOldEpoch();
     error Middleware__InvalidEpoch();
+    error Middleware__InvalidAddress();
+    error Middleware__InsufficientBalance();
     error Middleware__SlashingWindowTooShort();
     error Middleware__UnknownSlasherType();
-    error Middleware__InvalidAddress();
     error Middleware__OperatorNotFound(bytes32 operatorKey, uint48 epoch);
     error Middleware__SlashPercentageTooBig(uint48 epoch, address operator, uint256 percentage);
 

--- a/test/unit/Middleware.t.sol
+++ b/test/unit/Middleware.t.sol
@@ -1194,9 +1194,6 @@ contract MiddlewareTest is Test {
         middleware.setOperatorRewardsContract(address(operatorRewards));
         middleware.setGateway(gateway);
 
-        vm.startPrank(address(middleware));
-        token.approve(address(operatorRewards), 1000);
-
         uint256 epoch = 0;
         uint256 eraIndex = 0;
         uint256 totalPointsToken = 100;
@@ -1219,6 +1216,33 @@ contract MiddlewareTest is Test {
 
         vm.expectRevert(IMiddleware.Middleware__CallerNotGateway.selector);
         middleware.distributeRewards(epoch, eraIndex, totalPointsToken, tokensInflatedToken, rewardsRoot, tokenAddress);
+    }
+
+    function testDistributeRewardsWithInsufficientBalance() public {
+        uint48 OPERATOR_SHARE = 20;
+
+        uint256 epoch = 0;
+        uint256 eraIndex = 0;
+        uint256 totalPointsToken = 100;
+        uint256 tokensInflatedToken = 1000;
+        bytes32 rewardsRoot = 0x4b0ddd8b9b8ec6aec84bcd2003c973254c41d976f6f29a163054eec4e7947810;
+        address gateway = makeAddr("Gateway");
+
+        Token token = new Token("Test");
+        token.transfer(address(middleware), 800);
+
+        ODefaultOperatorRewards operatorRewards =
+            new ODefaultOperatorRewards(tanssi, address(networkMiddlewareService), address(token), OPERATOR_SHARE);
+
+        vm.startPrank(owner);
+        middleware.setOperatorRewardsContract(address(operatorRewards));
+        middleware.setGateway(gateway);
+
+        vm.startPrank(gateway);
+        vm.expectRevert(IMiddleware.Middleware__InsufficientBalance.selector);
+        middleware.distributeRewards(
+            epoch, eraIndex, totalPointsToken, tokensInflatedToken, rewardsRoot, address(token)
+        );
     }
 
     // ************************************************************************************************


### PR DESCRIPTION
Fix for bug in middleware which doesn't approve `ODefaultOperatorsRewards` contract for the safeTransfer.