### PR TITLE
Added sorting for operator keys based on their stakes

### DIFF
--- a/src/contracts/libraries/QuickSort.sol
+++ b/src/contracts/libraries/QuickSort.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {IMiddleware} from "../../interfaces/middleware/IMiddleware.sol";
+
+/**
+ * @title QuickSort library
+ * @notice This library is used to sort the validator data array in descending order of stakes
+ * @dev This library is used in the middleware to sort the validator data array in descending order of stakes
+ */
+library QuickSort {
+    function quickSort(
+        IMiddleware.ValidatorData[] memory arr,
+        int256 left,
+        int256 right
+    ) internal pure returns (IMiddleware.ValidatorData[] memory) {
+        _quickSort(arr, left, right);
+        return arr;
+    }
+
+    function _quickSort(IMiddleware.ValidatorData[] memory arr, int256 left, int256 right) public pure {
+        int256 i = left;
+        int256 j = right;
+        if (i == j) return;
+        uint256 pivot = arr[uint256(left + (right - left) / 2)].stake;
+        while (i <= j) {
+            while (arr[uint256(i)].stake > pivot) i++;
+            while (pivot > arr[uint256(j)].stake) j--;
+            if (i <= j) {
+                (arr[uint256(i)], arr[uint256(j)]) = (arr[uint256(j)], arr[uint256(i)]);
+                i++;
+                j--;
+            }
+        }
+        if (left < j) {
+            _quickSort(arr, left, j);
+        }
+        if (i < right) {
+            _quickSort(arr, i, right);
+        }
+    }
+}

--- a/test/unit/Middleware.t.sol
+++ b/test/unit/Middleware.t.sol
@@ -1638,11 +1638,10 @@ contract MiddlewareTest is Test {
         validators[3] = IMiddleware.ValidatorData(3, bytes32(uint256(3)));
         validators[4] = IMiddleware.ValidatorData(4, bytes32(uint256(4)));
 
-        IMiddleware.ValidatorData[] memory sortedValidators = validators.quickSort( 0, int256(validators.length - 1));
+        IMiddleware.ValidatorData[] memory sortedValidators = validators.quickSort(0, int256(validators.length - 1));
 
         for (uint256 i = 0; i < validators.length - 1; i++) {
             assertGe(sortedValidators[i].stake, sortedValidators[i + 1].stake);
         }
-            
     }
 }

--- a/test/unit/Middleware.t.sol
+++ b/test/unit/Middleware.t.sol
@@ -48,6 +48,7 @@ import {ODefaultOperatorRewards} from "src/contracts/rewarder/ODefaultOperatorRe
 import {Middleware} from "src/contracts/middleware/Middleware.sol";
 import {IMiddleware} from "src/interfaces/middleware/IMiddleware.sol";
 import {SimpleKeyRegistry32} from "src/contracts/libraries/SimpleKeyRegistry32.sol";
+import {QuickSort} from "src/contracts/libraries/QuickSort.sol";
 
 import {DelegatorMock} from "../mocks/symbiotic/DelegatorMock.sol";
 import {OptInServiceMock} from "../mocks/symbiotic/OptInServiceMock.sol";
@@ -57,6 +58,7 @@ import {Token} from "../mocks/Token.sol";
 
 contract MiddlewareTest is Test {
     using Subnetwork for address;
+    using QuickSort for IMiddleware.ValidatorData[];
 
     uint48 public constant NETWORK_EPOCH_DURATION = 6 days;
     uint48 public constant SLASHING_WINDOW = 7 days;
@@ -1622,5 +1624,25 @@ contract MiddlewareTest is Test {
         vm.expectEmit(true, true, false, false);
         emit IODefaultOperatorRewards.SetOperatorShare(newOperatorShare);
         middleware.setOperatorShareOnOperatorRewards(newOperatorShare);
+    }
+
+    // ************************************************************************************************
+    // *                                        QUICK SORT
+    // ************************************************************************************************
+
+    function testQuickSort() public {
+        IMiddleware.ValidatorData[] memory validators = new IMiddleware.ValidatorData[](5);
+        validators[0] = IMiddleware.ValidatorData(0, bytes32(0));
+        validators[1] = IMiddleware.ValidatorData(1, bytes32(uint256(1)));
+        validators[2] = IMiddleware.ValidatorData(2, bytes32(uint256(2)));
+        validators[3] = IMiddleware.ValidatorData(3, bytes32(uint256(3)));
+        validators[4] = IMiddleware.ValidatorData(4, bytes32(uint256(4)));
+
+        IMiddleware.ValidatorData[] memory sortedValidators = validators.quickSort( 0, int256(validators.length - 1));
+
+        for (uint256 i = 0; i < validators.length - 1; i++) {
+            assertGe(sortedValidators[i].stake, sortedValidators[i + 1].stake);
+        }
+            
     }
 }


### PR DESCRIPTION
- [ ] This PR adds initial benchmarking for getting big validators set and sort it
- [ ]  It's a proof of gas cost for specific scenarios

```

- To send 100 operators in 3 vaults: 7_404_958
- To send 250 operators in 3 vaults: 18_179_863
- To send 350 operators in 3 vaults: 25_436_554

With current gas price (0,000000004165366259) and current ETH price ($2590):

- 100: 7_404_958 * 0,000000004165366259 = 0,0308443622 ≈ $80
- 250: 18_179_863 * 0,000000004165366259 = 0,07572578793 ≈ $196
- 350: 25_436_554 * 0,000000004165366259 = 0,1059525638 ≈ $274

With gas ~bullrun (0,0000001) and estimated price of ($4200):

- 100: 7_404_958 * 0,0000001 = 0,7404958 ≈ $3100
- 250: 18_179_863 * 0,0000001 = 1,8179863 ≈ $7635
- 350: 25_436_554 * 0,0000001 = 2,5436554 ≈ $10683

With 500 operators we reach maximum gas so unusable 36_273_607 gas. Recently it has been upped to 36M 
```