### PR TITLE
[MD-987] - Fixed total operator shares and and operator limit for full restake

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,9 +41,9 @@ test :; forge test
 
 testv :; forge test -vvvv
 
-coverage :; forge coverage --nmp test/fork/*
+coverage :; forge coverage --nmp test/fork/* 
 
-coverage-fork :; forge coverage --mp test/fork/*
+coverage-fork :; forge coverage --mp test/fork/* --fork-url ${FORK_RPC_URL}
 
 dcoverage :; forge coverage --nmp test/fork/* --report debug > coverage.txt
 

--- a/src/contracts/middleware/MiddlewareStorage.sol
+++ b/src/contracts/middleware/MiddlewareStorage.sol
@@ -31,6 +31,7 @@ abstract contract MiddlewareStorage {
     bytes32 private constant MIDDLEWARE_STORAGE_LOCATION =
         0xca64b196a0d05040904d062f739ed1d1e1d3cc5de78f7001fb9039595fce9100;
 
+    uint8 public constant DEFAULT_DECIMALS = 18;
     uint256 public constant VERSION = 1;
     uint256 public constant PARTS_PER_BILLION = 1_000_000_000;
     bytes32 internal constant GATEWAY_ROLE = keccak256("GATEWAY_ROLE");

--- a/test/fork/Middleware.t.sol
+++ b/test/fork/Middleware.t.sol
@@ -71,7 +71,7 @@ contract MiddlewareTest is Test {
     uint48 public constant OPERATOR_SHARE = 1;
     uint128 public constant MAX_NETWORK_LIMIT = 1000 ether;
     uint128 public constant OPERATOR_NETWORK_LIMIT = 300 ether;
-    uint256 public constant TOTAL_NETWORK_SHARES = 3;
+    uint256 public constant TOTAL_NETWORK_SHARES = 2;
     uint256 public constant PARTS_PER_BILLION = 1_000_000_000;
     uint256 public constant SLASHING_FRACTION = PARTS_PER_BILLION / 10; // 10%
     uint8 public constant ORACLE_DECIMALS = 3;
@@ -452,9 +452,6 @@ contract MiddlewareTest is Test {
             _prepareSlashingTest();
 
         //Since vaultVetoed is full restake, it exactly gets the amount deposited, so no need to calculations
-        uint256 activeStakeInVetoed = ecosystemEntities.vaultVetoed.activeStake();
-        uint256 activePowerInVetoed = (activeStakeInVetoed * uint256(ORACLE_CONVERSION_TOKEN)) / 10 ** ORACLE_DECIMALS;
-        assertEq(activePowerInVetoed, totalFullRestakePower);
 
         assertEq(validators[1].power, totalOperator2Power);
         assertEq(validators[2].power, totalOperator3Power);
@@ -501,13 +498,10 @@ contract MiddlewareTest is Test {
         uint48 newEpoch = ecosystemEntities.middleware.getCurrentEpoch();
         validators = OBaseMiddlewareReader(address(ecosystemEntities.middleware)).getValidatorSet(newEpoch);
 
-        uint256 activeStakeInVetoed = ecosystemEntities.vaultVetoed.activeStake();
-        uint256 activePowerInVetoed = (activeStakeInVetoed * uint256(ORACLE_CONVERSION_TOKEN)) / 10 ** ORACLE_DECIMALS;
-
         (uint256 totalOperator2PowerAfter,) =
-            _calculateOperatorPower(totalPowerVaultSlashable, activePowerInVetoed, slashingPower);
+            _calculateOperatorPower(totalPowerVaultSlashable, totalFullRestakePower, slashingPower);
         (uint256 totalOperator3PowerAfter,) =
-            _calculateOperatorPower(totalPowerVault + totalPowerVaultSlashable, activePowerInVetoed, slashingPower);
+            _calculateOperatorPower(totalPowerVault + totalPowerVaultSlashable, totalFullRestakePower, slashingPower);
 
         assertEq(validators[1].power, totalOperator2PowerAfter);
         assertEq(validators[2].power, totalOperator3PowerAfter);
@@ -557,13 +551,10 @@ contract MiddlewareTest is Test {
         uint48 newEpoch = ecosystemEntities.middleware.getCurrentEpoch();
         validators = OBaseMiddlewareReader(address(ecosystemEntities.middleware)).getValidatorSet(newEpoch);
 
-        uint256 activeStakeInVetoed = ecosystemEntities.vaultVetoed.activeStake();
-        uint256 activePowerInVetoed = (activeStakeInVetoed * uint256(ORACLE_CONVERSION_TOKEN)) / 10 ** ORACLE_DECIMALS;
-
         (uint256 totalOperator2PowerAfter,) =
-            _calculateOperatorPower(totalPowerVaultSlashable, activePowerInVetoed, slashingPower);
+            _calculateOperatorPower(totalPowerVaultSlashable, totalFullRestakePower, slashingPower);
         (uint256 totalOperator3PowerAfter,) =
-            _calculateOperatorPower(totalPowerVault + totalPowerVaultSlashable, activePowerInVetoed, slashingPower);
+            _calculateOperatorPower(totalPowerVault + totalPowerVaultSlashable, totalFullRestakePower, slashingPower);
 
         assertEq(validators[1].power, totalOperator2PowerAfter);
         assertEq(validators[2].power, totalOperator3PowerAfter);

--- a/test/fork/Middleware.t.sol
+++ b/test/fork/Middleware.t.sol
@@ -245,7 +245,7 @@ contract MiddlewareTest is Test {
         }
 
         {
-            totalFullRestakePower = ((OPERATOR_STAKE * 2) * uint256(ORACLE_CONVERSION_TOKEN)) / 10 ** ORACLE_DECIMALS;
+            totalFullRestakePower = (OPERATOR_STAKE * uint256(ORACLE_CONVERSION_TOKEN)) / 10 ** ORACLE_DECIMALS;
 
             totalPowerVault = (OPERATOR_STAKE * 2 * uint256(ORACLE_CONVERSION_TOKEN)) / 10 ** ORACLE_DECIMALS;
             totalPowerVaultSlashable = (OPERATOR_STAKE * 2 * uint256(ORACLE_CONVERSION_TOKEN)) / 10 ** ORACLE_DECIMALS;
@@ -303,15 +303,9 @@ contract MiddlewareTest is Test {
             tanssi.subnetwork(0), operator, OPERATOR_SHARE
         );
         INetworkRestakeDelegator(vaultAddresses.delegator).setOperatorNetworkShares(
-            tanssi.subnetwork(0), operator2, OPERATOR_SHARE
-        );
-        INetworkRestakeDelegator(vaultAddresses.delegator).setOperatorNetworkShares(
             tanssi.subnetwork(0), operator3, OPERATOR_SHARE
         );
 
-        INetworkRestakeDelegator(vaultAddresses.delegatorSlashable).setOperatorNetworkShares(
-            tanssi.subnetwork(0), operator, OPERATOR_SHARE
-        );
         INetworkRestakeDelegator(vaultAddresses.delegatorSlashable).setOperatorNetworkShares(
             tanssi.subnetwork(0), operator2, OPERATOR_SHARE
         );
@@ -336,13 +330,10 @@ contract MiddlewareTest is Test {
     ) public {
         vm.startPrank(_owner);
         IFullRestakeDelegator(vaultAddresses.delegatorVetoed).setOperatorNetworkLimit(
-            tanssi.subnetwork(0), operator, OPERATOR_NETWORK_LIMIT
+            tanssi.subnetwork(0), operator2, OPERATOR_STAKE
         );
         IFullRestakeDelegator(vaultAddresses.delegatorVetoed).setOperatorNetworkLimit(
-            tanssi.subnetwork(0), operator2, OPERATOR_NETWORK_LIMIT
-        );
-        IFullRestakeDelegator(vaultAddresses.delegatorVetoed).setOperatorNetworkLimit(
-            tanssi.subnetwork(0), operator3, OPERATOR_NETWORK_LIMIT
+            tanssi.subnetwork(0), operator3, OPERATOR_STAKE
         );
         vm.stopPrank();
     }
@@ -569,9 +560,9 @@ contract MiddlewareTest is Test {
         uint256 activeStakeInVetoed = ecosystemEntities.vaultVetoed.activeStake();
         uint256 activePowerInVetoed = (activeStakeInVetoed * uint256(ORACLE_CONVERSION_TOKEN)) / 10 ** ORACLE_DECIMALS;
 
-        (uint256 totalOperator2PowerAfter, uint256 powerFromSharesOperator2After) =
+        (uint256 totalOperator2PowerAfter,) =
             _calculateOperatorPower(totalPowerVaultSlashable, activePowerInVetoed, slashingPower);
-        (uint256 totalOperator3PowerAfter, uint256 powerFromSharesOperator3After) =
+        (uint256 totalOperator3PowerAfter,) =
             _calculateOperatorPower(totalPowerVault + totalPowerVaultSlashable, activePowerInVetoed, slashingPower);
 
         assertEq(validators[1].power, totalOperator2PowerAfter);
@@ -609,7 +600,6 @@ contract MiddlewareTest is Test {
         uint256 slashingPower = (SLASHING_FRACTION * powerFromSharesOperator2) / PARTS_PER_BILLION;
 
         vm.prank(gateway);
-        //! Why this slash should anyway go through if operator was paused? Shouldn't it revert?
         ecosystemEntities.middleware.slash(currentEpoch, OPERATOR2_KEY, SLASHING_FRACTION);
 
         vm.warp(block.timestamp + SLASHING_WINDOW + 1);

--- a/test/unit/Deploy.t.sol
+++ b/test/unit/Deploy.t.sol
@@ -583,7 +583,6 @@ contract DeployTest is Test {
     //**************************************************************************************************
     function testDeployVaultWithCollateralEmpty() public {
         (, IVaultConfigurator vaultConfigurator,) = deployTanssiEcosystem.ecosystemEntities();
-        (Token stETHToken,,) = deployTanssiEcosystem.tokensAddresses();
 
         DeployVault.CreateVaultBaseParams memory params = DeployVault.CreateVaultBaseParams({
             epochDuration: VAULT_EPOCH_DURATION,


### PR DESCRIPTION
This PR fixes:

- attribution of operator shares and operator network limits, respectively for `NetworkRestake` and `FullRestake`, to be congruent with their partecipation in vaults.
- Minor fixes with unused variables and added constant for decimals

This PR also assess the soundness of math for `stakeToPower`.