### PR TITLE
[MD-1003] Send sorted operators to substrate

### DIFF
--- a/src/contracts/middleware/Middleware.sol
+++ b/src/contracts/middleware/Middleware.sol
@@ -283,7 +283,6 @@ contract Middleware is
      * @inheritdoc IMiddleware
      */
     function sendCurrentOperatorsKeys() external returns (bytes32[] memory sortedKeys) {
-        // TODO: How come this is not gated?
         address gateway = getGateway();
         if (gateway == address(0)) {
             revert Middleware__GatewayNotSet();

--- a/src/contracts/middleware/Middleware.sol
+++ b/src/contracts/middleware/Middleware.sol
@@ -289,7 +289,7 @@ contract Middleware is
         }
 
         uint48 epoch = getCurrentEpoch();
-        sortedKeys = IOBaseMiddlewareReader(address(this)).sortOperatorsByVaults(epoch);
+        sortedKeys = IOBaseMiddlewareReader(address(this)).sortOperatorsByPower(epoch);
         IOGateway(gateway).sendOperatorsData(sortedKeys, epoch);
     }
 
@@ -297,13 +297,13 @@ contract Middleware is
      * @inheritdoc AutomationCompatibleInterface
      * @dev Called by chainlink nodes off-chain to check if the upkeep is needed
      * @return upkeepNeeded boolean to indicate whether the keeper should call performUpkeep or not.
-     * @return performData bytes of the sorted operators' keys and the epoch that will be used by the keeper when calling performUpkeep, if upkeep is needed.
+     * @return performData bytes of the sorted (by power) operators' keys and the epoch that will be used by the keeper when calling performUpkeep, if upkeep is needed.
      */
     function checkUpkeep(
         bytes calldata /* checkData */
     ) external view override returns (bool upkeepNeeded, bytes memory performData) {
         uint48 epoch = getCurrentEpoch();
-        bytes32[] memory sortedKeys = IOBaseMiddlewareReader(address(this)).sortOperatorsByVaults(epoch);
+        bytes32[] memory sortedKeys = IOBaseMiddlewareReader(address(this)).sortOperatorsByPower(epoch);
         StorageMiddleware storage $ = _getMiddlewareStorage();
 
         //Should be at least once per epoch

--- a/src/contracts/middleware/Middleware.sol
+++ b/src/contracts/middleware/Middleware.sol
@@ -283,6 +283,7 @@ contract Middleware is
      * @inheritdoc IMiddleware
      */
     function sendCurrentOperatorsKeys() external returns (bytes32[] memory sortedKeys) {
+        // TODO: How come this is not gated?
         address gateway = getGateway();
         if (gateway == address(0)) {
             revert Middleware__GatewayNotSet();

--- a/src/contracts/middleware/OBaseMiddlewareReader.sol
+++ b/src/contracts/middleware/OBaseMiddlewareReader.sol
@@ -519,11 +519,11 @@ contract OBaseMiddlewareReader is MiddlewareStorage, EpochCapture, VaultManager,
     }
 
     /**
-     * @dev Sorts operators by their total stake in descending order, after 500 it will be almost impossible to be used on-chain since 500 ≈ 36M gas
+     * @dev Sorts operators by their total power in descending order, after 500 it will be almost impossible to be used on-chain since 500 ≈ 36M gas
      * @param epoch The epoch number
-     * @return sortedKeys Array of sorted operators keys based on their stake
+     * @return sortedKeys Array of sorted operators keys based on their power
      */
-    function sortOperatorsByVaults(
+    function sortOperatorsByPower(
         uint48 epoch
     ) public view returns (bytes32[] memory sortedKeys) {
         IMiddleware.ValidatorData[] memory validatorSet = getValidatorSet(epoch);

--- a/src/interfaces/middleware/IOBaseMiddlewareReader.sol
+++ b/src/interfaces/middleware/IOBaseMiddlewareReader.sol
@@ -167,7 +167,7 @@ interface IOBaseMiddlewareReader {
         address vault
     ) external view returns (bool);
 
-    function sortOperatorsByVaults(
+    function sortOperatorsByPower(
         uint48 epoch
     ) external view returns (bytes32[] memory sortedKeys);
 

--- a/test/integration/Middleware.t.sol
+++ b/test/integration/Middleware.t.sol
@@ -1094,7 +1094,7 @@ contract MiddlewareTest is Test {
 
         uint256 gasBefore = gasleft();
         bytes32[] memory sortedValidators =
-            OBaseMiddlewareReader(address(middleware)).sortOperatorsByVaults(currentEpoch);
+            OBaseMiddlewareReader(address(middleware)).sortOperatorsByPower(currentEpoch);
         uint256 gasAfter = gasleft();
 
         uint256 gasSorted = gasBefore - gasAfter;
@@ -1132,7 +1132,7 @@ contract MiddlewareTest is Test {
 
         uint256 gasBefore = gasleft();
         bytes32[] memory sortedValidators =
-            OBaseMiddlewareReader(address(middleware)).sortOperatorsByVaults(currentEpoch);
+            OBaseMiddlewareReader(address(middleware)).sortOperatorsByPower(currentEpoch);
         uint256 gasAfter = gasleft();
         uint256 gasSorted = gasBefore - gasAfter;
         console2.log("Total gas used: ", gasSorted);
@@ -1170,7 +1170,7 @@ contract MiddlewareTest is Test {
 
         uint256 gasBefore = gasleft();
         bytes32[] memory sortedValidators =
-            OBaseMiddlewareReader(address(middleware)).sortOperatorsByVaults(currentEpoch);
+            OBaseMiddlewareReader(address(middleware)).sortOperatorsByPower(currentEpoch);
         uint256 gasAfter = gasleft();
         uint256 gasSorted = gasBefore - gasAfter;
         console2.log("Total gas used: ", gasSorted);
@@ -1227,7 +1227,7 @@ contract MiddlewareTest is Test {
 
         uint256 gasBefore = gasleft();
         bytes32[] memory sortedValidators =
-            OBaseMiddlewareReader(address(middleware)).sortOperatorsByVaults(currentEpoch);
+            OBaseMiddlewareReader(address(middleware)).sortOperatorsByPower(currentEpoch);
         uint256 gasAfter = gasleft();
         uint256 gasSorted = gasBefore - gasAfter;
         console2.log("Total gas used: ", gasSorted);

--- a/test/integration/Middleware.t.sol
+++ b/test/integration/Middleware.t.sol
@@ -58,7 +58,6 @@ import {MockV3Aggregator} from "@chainlink/tests/MockV3Aggregator.sol";
 //**************************************************************************************************
 //                                      OPENZEPPELIN
 //**************************************************************************************************
-import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
@@ -1342,5 +1341,39 @@ contract MiddlewareTest is Test {
     function _deployOracle(uint8 decimals, int256 answer) public returns (address) {
         MockV3Aggregator oracle = new MockV3Aggregator(decimals, answer);
         return address(oracle);
+    }
+
+    // ************************************************************************************************
+    // *                                  SEND CURRENT OPERATORS KEYS
+    // ************************************************************************************************
+
+    function testSendCurrentOperatorKeysOrderChangesIfPowerChanges() public {
+        vm.mockCall(address(gateway), abi.encodeWithSelector(IOGateway.sendOperatorsData.selector), new bytes(0));
+
+        vm.warp(NETWORK_EPOCH_DURATION + 2);
+        bytes32[] memory keys = middleware.sendCurrentOperatorsKeys();
+        assertEq(keys.length, 3);
+
+        // OP3 > OP2 > OP1 (In terms of power)
+        assertEq(keys[0], OPERATOR3_KEY);
+        assertEq(keys[1], OPERATOR2_KEY);
+        assertEq(keys[2], OPERATOR_KEY);
+
+        vm.startPrank(owner);
+        // This doesn't remove operator3's stake, but turns his power to zero, so it is not only the top operator.
+        // Withdrawing would not change the order since this vault is full restake giving both OP3 and OP2 the same power.
+        IFullRestakeDelegator(vaultAddresses.delegatorVetoed).setOperatorNetworkLimit(
+            tanssi.subnetwork(0), operator3, 0
+        );
+
+        vm.warp(block.timestamp + VAULT_EPOCH_DURATION + 1);
+
+        keys = middleware.sendCurrentOperatorsKeys();
+        assertEq(keys.length, 3);
+
+        // Now OP2 > OP3 > OP1 (In terms of power)
+        assertEq(keys[0], OPERATOR2_KEY);
+        assertEq(keys[1], OPERATOR3_KEY);
+        assertEq(keys[2], OPERATOR_KEY);
     }
 }

--- a/test/unit/Middleware.t.sol
+++ b/test/unit/Middleware.t.sol
@@ -53,7 +53,6 @@ import {AggregatorV3Interface} from "@chainlink/shared/interfaces/AggregatorV2V3
 //**************************************************************************************************
 //                                      OPENZEPPELIN
 //**************************************************************************************************
-import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 
@@ -2440,7 +2439,7 @@ contract MiddlewareTest is Test {
 
     function _prepareInitializeTest() private returns (Middleware middleware2, IMiddleware.InitParams memory params) {
         middleware2 = Middleware(address(new MiddlewareProxy(address(middlewareImpl), "")));
-        address readHelper = address(new OBaseMiddlewareReader());
+        address readHelper_ = address(new OBaseMiddlewareReader());
         params = IMiddleware.InitParams({
             network: tanssi,
             operatorRegistry: address(registry),
@@ -2449,7 +2448,7 @@ contract MiddlewareTest is Test {
             owner: owner,
             epochDuration: NETWORK_EPOCH_DURATION,
             slashingWindow: SLASHING_WINDOW,
-            reader: readHelper
+            reader: readHelper_
         });
     }
 


### PR DESCRIPTION
In `performUpkeep` and `sendCurrentOperatorsKeys` we were already getting operators sorted by power.
However there was a proper test missing. I added it in integration tests where there is a better environment configured to asses the order is correct and that it changes when power changes. On unit tests I gave it a tried but I had to mock so many things that it didn't really make sense.

Renamed `sortOperatorsByVaults` to `sortOperatorsByPower`, which seems a clearer name for me. I checked and this method does not exist on the SDK so I'm not breaking any compatiblity, this is just for us.

Also added a comment on `sendCurrentOperatorsKeys`, I think the method should be gated since it calls the gateway, right now anyone can call it.