### PR TITLE
Prevents registration of empty keys for operators.

### DIFF
--- a/src/contracts/middleware/Middleware.sol
+++ b/src/contracts/middleware/Middleware.sol
@@ -39,6 +39,7 @@ import {ISlasher} from "@symbiotic/interfaces/slasher/ISlasher.sol";
 import {IVetoSlasher} from "@symbiotic/interfaces/slasher/IVetoSlasher.sol";
 import {Subnetwork} from "@symbiotic/contracts/libraries/Subnetwork.sol";
 import {Operators} from "@symbiotic-middleware/extensions/operators/Operators.sol";
+import {BaseOperators} from "@symbiotic-middleware/extensions/operators/BaseOperators.sol";
 import {KeyManager256} from "@symbiotic-middleware/extensions/managers/keys/KeyManager256.sol";
 import {OzAccessControl} from "@symbiotic-middleware/extensions/managers/access/OzAccessControl.sol";
 import {EpochCapture} from "@symbiotic-middleware/extensions/managers/capture-timestamps/EpochCapture.sol";
@@ -426,6 +427,9 @@ contract Middleware is
         }
     }
 
+    /**
+     * @inheritdoc OSharedVaults
+     */
     function _afterRegisterSharedVault(
         address sharedVault,
         IODefaultStakerRewards.InitParams memory stakerRewardsParams
@@ -439,6 +443,22 @@ contract Middleware is
         _setVaultToCollateral(sharedVault, collateral);
     }
 
+    /**
+     * @inheritdoc BaseOperators
+     */
+    function _beforeRegisterOperator(
+        address operator,
+        bytes memory key,
+        address
+    ) internal pure override notZeroAddress(operator) {
+        if (abi.decode(key, (bytes32)) == bytes32(0)) {
+            revert Middleware__InvalidKey();
+        }
+    }
+
+    /**
+     * @inheritdoc BaseOperators
+     */
     function _beforeUnregisterOperator(
         address operator
     ) internal override {

--- a/src/contracts/middleware/OBaseMiddlewareReader.sol
+++ b/src/contracts/middleware/OBaseMiddlewareReader.sol
@@ -635,11 +635,6 @@ contract OBaseMiddlewareReader is MiddlewareStorage, EpochCapture, VaultManager,
                 ++i;
             }
             bytes32 key = abi.decode(getOperatorKeyAt(operator, epochStartTs), (bytes32));
-
-            if (key == bytes32(0)) {
-                continue;
-            }
-
             uint256 power = _getOperatorPowerAt(epochStartTs, operator);
             validatorSet[len++] = IMiddleware.ValidatorData(power, key);
         }

--- a/src/interfaces/middleware/IMiddleware.sol
+++ b/src/interfaces/middleware/IMiddleware.sol
@@ -48,6 +48,7 @@ interface IMiddleware {
     error Middleware__InvalidEpoch();
     error Middleware__InvalidEpochDuration();
     error Middleware__InvalidAddress();
+    error Middleware__InvalidKey();
     error Middleware__InvalidInterval();
     error Middleware__InsufficientBalance();
     error Middleware__NotSupportedCollateral(address collateral);


### PR DESCRIPTION
Since empty keys are no longer an option, removes unreachable check on Reader and test.

Addreses https://github.com/moondance-labs/tanssi-sr-labs/issues/29