### PR TITLE
Only distribute rewards to vaults with actual amount after distribution.

### DIFF
--- a/src/contracts/rewarder/ODefaultOperatorRewards.sol
+++ b/src/contracts/rewarder/ODefaultOperatorRewards.sol
@@ -295,11 +295,13 @@ contract ODefaultOperatorRewards is
     ) private {
         OperatorRewardsStorage storage $ = _getOperatorRewardsStorage();
         for (uint256 i; i < totalVaults;) {
-            address stakerRewardsForVault = $.vaultToStakerRewardsContract[operatorVaults[i]];
-            IERC20(tokenAddress).approve(stakerRewardsForVault, amountPerVault[i]);
-            IODefaultStakerRewards(stakerRewardsForVault).distributeRewards(
-                epoch, eraIndex, amountPerVault[i], tokenAddress, data
-            );
+            if (amountPerVault[i] != 0) {
+                address stakerRewardsForVault = $.vaultToStakerRewardsContract[operatorVaults[i]];
+                IERC20(tokenAddress).approve(stakerRewardsForVault, amountPerVault[i]);
+                IODefaultStakerRewards(stakerRewardsForVault).distributeRewards(
+                    epoch, eraIndex, amountPerVault[i], tokenAddress, data
+                );
+            }
 
             unchecked {
                 ++i;


### PR DESCRIPTION
Adds simple check was added to ignore distributing rewards to a vault (its staker rewards contract) if final calculation is 0, so it won't revert on later checks.

Addresses https://github.com/PashovAuditGroup/Tanssi_April25_MERGED/issues/81