### PR TITLE
[L-06] Constructor of ODefaultOperatorRewards missing disableInitializers() call

### DIFF
--- a/src/contracts/rewarder/ODefaultOperatorRewards.sol
+++ b/src/contracts/rewarder/ODefaultOperatorRewards.sol
@@ -93,6 +93,7 @@ contract ODefaultOperatorRewards is
         address network,
         address networkMiddlewareService
     ) notZeroAddress(network) notZeroAddress(networkMiddlewareService) {
+        _disableInitializers();
         i_network = network;
         i_networkMiddlewareService = networkMiddlewareService;
     }


### PR DESCRIPTION
https://github.com/PashovAuditGroup/Tanssi_April25_MERGED/issues/46