### PR TITLE
Ignores operators with power 0 when getting validator set.

### DIFF
--- a/src/contracts/middleware/Middleware.sol
+++ b/src/contracts/middleware/Middleware.sol
@@ -395,6 +395,20 @@ contract Middleware is
     }
 
     /**
+     * @dev Set the reader address.
+     * @param reader The MiddlewareReader address
+     */
+    function setReader(
+        address reader
+    ) external checkAccess notZeroAddress(reader) {
+        // From BaseMiddleware.sol
+        bytes32 ReaderStorageLocation = 0xfd87879bc98f37af7578af722aecfbe5843e5ad354da2d1e70cb5157c4ec8800;
+        assembly {
+            sstore(ReaderStorageLocation, reader)
+        }
+    }
+
+    /**
      * @dev Get vault stake and calculate slashing amount.
      * @param vault The vault address to calculate its stake
      * @param params Struct containing slashing parameters

--- a/src/contracts/middleware/OBaseMiddlewareReader.sol
+++ b/src/contracts/middleware/OBaseMiddlewareReader.sol
@@ -647,7 +647,7 @@ contract OBaseMiddlewareReader is
             }
             bytes32 key = abi.decode(getOperatorKeyAt(operator, epochStartTs), (bytes32));
             uint256 power = _getOperatorPowerAt(epochStartTs, operator);
-            if (key != bytes32(0)) {
+            if (key != bytes32(0) && power != 0) {
                 validatorSet[len++] = IMiddleware.ValidatorData(power, key);
             }
         }

--- a/test/integration/Middleware.t.sol
+++ b/test/integration/Middleware.t.sol
@@ -1036,11 +1036,18 @@ contract MiddlewareTest is Test {
             _registerOperatorAndOptIn(_operator, tanssi, address(_vault), true);
             vm.startPrank(_operator);
             uint256 depositAmount = 0.001 ether * (i + 1);
-            _depositToVault(Vault(_vault), _operator, 0.001 ether * (i + 1), token);
+            _depositToVault(Vault(_vault), _operator, depositAmount, token);
+
             vm.startPrank(owner);
-            if (i % 3 != 1) {
+            if (i % 3 == 1) {
+                // FULL_RESTAKE, needs to set the operator network limit
+                IFullRestakeDelegator(_delegator).setOperatorNetworkLimit(
+                    tanssi.subnetwork(0), _operator, OPERATOR_STAKE_BTC
+                );
+            } else {
+                // NETWORK_RESTAKE, needs to set the operator network shares
                 INetworkRestakeDelegator(_delegator).setOperatorNetworkShares(
-                    tanssi.subnetwork(0), _operator, depositAmount
+                    tanssi.subnetwork(0), _operator, OPERATOR_SHARE
                 );
             }
             bytes32 operatorKey = bytes32(uint256(i + 4));


### PR DESCRIPTION
Took the chance to refactor Middleware unit tests by extracting common operations from most tests.
Also fixed sorting tests on Middleware integration tests, where operators using full restake vault were missing the setting of network limit.