### PR TITLE
[MD-1236] Fork tests deploying and configuring TANSSI vault on mainnet

### DIFF
--- a/script/DeployVault.s.sol
+++ b/script/DeployVault.s.sol
@@ -96,7 +96,11 @@ contract DeployVault is Script {
         });
     }
 
-    function createTanssiVault(address vaultConfigurator, address admin, address collateral) public {
+    function createTanssiVault(
+        address vaultConfigurator,
+        address admin,
+        address collateral
+    ) public returns (address vault, address delegator, address slasher) {
         CreateVaultBaseParams memory params = CreateVaultBaseParams({
             epochDuration: 7 days,
             depositWhitelist: false,
@@ -110,7 +114,7 @@ contract DeployVault is Script {
             network: address(0),
             burner: address(0xDead)
         });
-        _createVault(params, VaultManager.SlasherType.INSTANT, true, 0);
+        (vault, delegator, slasher) = _createVault(params, VaultManager.SlasherType.INSTANT, true, 0);
     }
 
     function _createVault(

--- a/test/fork/mainnet/Full.t.sol
+++ b/test/fork/mainnet/Full.t.sol
@@ -1675,7 +1675,6 @@ contract FullTest is Test {
     }
 
     function testTanssiVaultCanDistributeOperatorRewards() public {
-        vm.skip(true); // TODO: Unskip once staker rewards factory is fixed on mainnet.
         _configureTanssiVault();
 
         // We reuse case 3 were opslayer has rewards.
@@ -1693,7 +1692,6 @@ contract FullTest is Test {
     }
 
     function testTanssiVaultCanDistributeStakerRewards() public {
-        vm.skip(true); // TODO: Unskip once staker rewards factory is fixed on mainnet.
         _configureTanssiVault();
 
         // We reuse case 3 were opslayer has rewards.
@@ -1727,6 +1725,20 @@ contract FullTest is Test {
 
     function _configureTanssiVault() private returns (HelperConfig.VaultData memory vaultData) {
         (address vaultConfigurator,,,,,,,,) = helperConfig.activeNetworkConfig();
+
+        // TODO: Remove when factory is fixed, currently it points the wrong network and operator rewards
+        {
+            (,,, address vaultRegistry,,, address networkMiddlewareService,,) = helperConfig.activeNetworkConfig();
+            DeployRewards deployRewards = new DeployRewards();
+            address stakerRewardsFactory = deployRewards.deployStakerRewardsFactoryContract(
+                vaultRegistry, networkMiddlewareService, address(operatorRewards), tanssi
+            );
+            DeployTanssiEcosystem deployTanssiEcosystem = new DeployTanssiEcosystem();
+            deployTanssiEcosystem.upgradeMiddleware(
+                address(middleware), 1, address(operatorRewards), stakerRewardsFactory, admin
+            );
+        }
+        // Remove until here
 
         DeployVault deployVault = new DeployVault();
         (address tanssiVaultAddress, address tanssiDelegatorAddress, address tanssiSlasherAddress) =


### PR DESCRIPTION
The fork tests deploy and configure a TANSSI vault, setting up OpsLayer as operator. 
Distribution of rewards for operators and stakers is tested. Slashing is also tested.

There is a temporary code included to redeploy Staker Rewards Factory and ugprade Middleware, since current version on mainnet has wrong addresses and cause rewards distribution from newly deployed vaults to fail.