### PR TITLE
Removes unnecesary prank when deploy staker rewards factory.

### DIFF
--- a/script/DeployRewards.s.sol
+++ b/script/DeployRewards.s.sol
@@ -83,8 +83,6 @@ contract DeployRewards is Script {
     ) public returns (address) {
         if (!isTest) {
             vm.startBroadcast(broadcaster());
-        } else {
-            vm.startPrank(owner_);
         }
         stakerRewardsFactory = new ODefaultStakerRewardsFactory(
             vaultFactory, networkMiddlewareService, operatorRewardsAddress, network, owner_
@@ -93,8 +91,6 @@ contract DeployRewards is Script {
 
         if (!isTest) {
             vm.stopBroadcast();
-        } else {
-            vm.stopPrank();
         }
 
         return address(stakerRewardsFactory);


### PR DESCRIPTION
I think this was added before the owner was passed as parameter to the Factory, I ran local, testnet and mainnet tests and they all pass.