### PR TITLE
[H-03] Adds test showing operators cannot change during an epoch

### DIFF
--- a/test/fork/testnet/Middleware.t.sol
+++ b/test/fork/testnet/Middleware.t.sol
@@ -177,7 +177,7 @@ contract MiddlewareTest is Test {
     }
 
     function testIfOperatorsAreRegisteredInVaults() public {
-        vm.warp(block.timestamp + NETWORK_EPOCH_DURATION + 1);
+        vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION + 1);
         uint48 currentEpoch = middleware.getCurrentEpoch();
         Middleware.OperatorVaultPair[] memory operatorVaultPairs =
             OBaseMiddlewareReader(address(middleware)).getOperatorVaultPairs(currentEpoch);
@@ -188,7 +188,7 @@ contract MiddlewareTest is Test {
     }
 
     function testOperatorsAreRegisteredAfterOneEpoch() public {
-        vm.warp(block.timestamp + NETWORK_EPOCH_DURATION + 1);
+        vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION + 1);
         uint48 currentEpoch = middleware.getCurrentEpoch();
 
         Middleware.OperatorVaultPair[] memory operatorVaultPairs =
@@ -200,12 +200,12 @@ contract MiddlewareTest is Test {
     }
 
     function testOperatorsStakeIsTheSamePerEpoch() public {
-        vm.warp(block.timestamp + NETWORK_EPOCH_DURATION + 1);
+        vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION + 1);
         uint48 previousEpoch = middleware.getCurrentEpoch();
         Middleware.ValidatorData[] memory validatorsPreviousEpoch =
             OBaseMiddlewareReader(address(middleware)).getValidatorSet(previousEpoch);
 
-        vm.warp(block.timestamp + NETWORK_EPOCH_DURATION + 1);
+        vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION + 1);
         Middleware.ValidatorData[] memory validators =
             OBaseMiddlewareReader(address(middleware)).getValidatorSet(previousEpoch);
         assertEq(validators.length, validatorsPreviousEpoch.length);
@@ -221,7 +221,7 @@ contract MiddlewareTest is Test {
         vm.prank(operator);
         vault.withdraw(operator, withdrawAmount);
 
-        vm.warp(block.timestamp + VAULT_EPOCH_DURATION * 2 + 1);
+        vm.warp(vm.getBlockTimestamp() + VAULT_EPOCH_DURATION * 2 + 1);
         currentEpoch = vault.currentEpoch();
 
         vm.prank(operator);
@@ -246,7 +246,7 @@ contract MiddlewareTest is Test {
         vm.prank(gateway);
         middleware.slash(currentEpoch, operatorData.operatorKey, SLASHING_FRACTION);
 
-        vm.warp(block.timestamp + SLASHING_WINDOW + 1);
+        vm.warp(vm.getBlockTimestamp() + SLASHING_WINDOW + 1);
         uint48 newEpoch = middleware.getCurrentEpoch();
         validators = OBaseMiddlewareReader(address(middleware)).getValidatorSet(newEpoch);
 
@@ -267,7 +267,7 @@ contract MiddlewareTest is Test {
         vm.prank(gateway);
         middleware.slash(currentEpoch, operatorData.operatorKey, SLASHING_FRACTION);
 
-        vm.warp(block.timestamp + SLASHING_WINDOW + 1);
+        vm.warp(vm.getBlockTimestamp() + SLASHING_WINDOW + 1);
         uint48 newEpoch = middleware.getCurrentEpoch();
         Middleware.ValidatorData[] memory validators =
             OBaseMiddlewareReader(address(middleware)).getValidatorSet(newEpoch);
@@ -293,7 +293,7 @@ contract MiddlewareTest is Test {
         vm.prank(gateway);
         middleware.slash(currentEpoch, operatorData.operatorKey, SLASHING_FRACTION);
 
-        vm.warp(block.timestamp + SLASHING_WINDOW + 1);
+        vm.warp(vm.getBlockTimestamp() + SLASHING_WINDOW + 1);
         uint48 newEpoch = middleware.getCurrentEpoch();
         Middleware.ValidatorData[] memory validators =
             OBaseMiddlewareReader(address(middleware)).getValidatorSet(newEpoch);
@@ -314,7 +314,7 @@ contract MiddlewareTest is Test {
         public
         returns (uint48 currentEpoch, Middleware.ValidatorData[] memory validators, uint256 totalOperatorPower)
     {
-        vm.warp(block.timestamp + NETWORK_EPOCH_DURATION + SLASHING_WINDOW - 1);
+        vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION + SLASHING_WINDOW - 1);
         currentEpoch = middleware.getCurrentEpoch();
 
         validators = OBaseMiddlewareReader(address(middleware)).getValidatorSet(currentEpoch);

--- a/test/integration/Full.t.sol
+++ b/test/integration/Full.t.sol
@@ -925,12 +925,12 @@ contract FullTest is Test {
         assertEq(validators[0].power, expectedOperatorPower1);
 
         // Power should not change until the network epoch ends
-        vm.warp(block.timestamp + NETWORK_EPOCH_DURATION / 2);
+        vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION / 2);
         validators = middlewareReader.getValidatorSet(middleware.getCurrentEpoch());
         assertEq(validators[0].power, expectedOperatorPower1);
 
         // Power changes even before the vault epoch ends, only network epoch needs to
-        vm.warp(block.timestamp + NETWORK_EPOCH_DURATION);
+        vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION);
         expectedOperatorPower1 += operator1_additional_stake.mulDiv(10 ** 18, 10 ** TOKEN_DECIMALS_USDC); // Normalized to 18 decimals
         validators = middlewareReader.getValidatorSet(middleware.getCurrentEpoch());
         assertEq(validators[0].power, expectedOperatorPower1);
@@ -953,12 +953,12 @@ contract FullTest is Test {
         assertEq(validators[0].power, expectedOperatorPower1);
 
         // Power should not change until the network epoch ends
-        vm.warp(block.timestamp + NETWORK_EPOCH_DURATION / 2);
+        vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION / 2);
         validators = middlewareReader.getValidatorSet(middleware.getCurrentEpoch());
         assertEq(validators[0].power, expectedOperatorPower1);
 
         // Power changes even before the vault epoch ends, only network epoch needs to
-        vm.warp(block.timestamp + NETWORK_EPOCH_DURATION);
+        vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION);
         expectedOperatorPower1 -= operator1_withdraw_stake.mulDiv(10 ** 18, 10 ** TOKEN_DECIMALS_USDC); // Normalized to 18 decimals
         validators = middlewareReader.getValidatorSet(middleware.getCurrentEpoch());
         assertEq(validators[0].power, expectedOperatorPower1);
@@ -1013,7 +1013,7 @@ contract FullTest is Test {
         middleware.registerOperator(operator8, abi.encode(OPERATOR8_KEY), address(0));
         vm.stopPrank();
 
-        vm.warp(block.timestamp + VAULT_EPOCH_DURATION);
+        vm.warp(vm.getBlockTimestamp() + VAULT_EPOCH_DURATION);
 
         Middleware.ValidatorData[] memory validators = middlewareReader.getValidatorSet(middleware.getCurrentEpoch());
 
@@ -1299,7 +1299,7 @@ contract FullTest is Test {
         // Pause and unregister
         vm.startPrank(owner);
         middleware.pauseOperator(operator7);
-        vm.warp(block.timestamp + SLASHING_WINDOW + 1);
+        vm.warp(vm.getBlockTimestamp() + SLASHING_WINDOW + 1);
         middleware.unregisterOperator(operator7);
 
         // Try to claim afterwards
@@ -2008,9 +2008,9 @@ contract FullTest is Test {
 
         // Then we try unregistering and registering again
         middleware.pauseOperator(operator2);
-        vm.warp(block.timestamp + SLASHING_WINDOW + 1);
+        vm.warp(vm.getBlockTimestamp() + SLASHING_WINDOW + 1);
         middleware.unregisterOperator(operator2);
-        vm.warp(block.timestamp + SLASHING_WINDOW + 1);
+        vm.warp(vm.getBlockTimestamp() + SLASHING_WINDOW + 1);
 
         vm.startPrank(operator2);
         // operatorRegistry.unregisterOperator(); // No such a thing. Only registering is possible.
@@ -2024,7 +2024,7 @@ contract FullTest is Test {
         operatorVaultOptInService.optIn(address(vaultsData.v2.vault));
         vm.stopPrank();
 
-        vm.warp(block.timestamp + NETWORK_EPOCH_DURATION + 1);
+        vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION + 1);
 
         vm.startPrank(owner);
         vm.expectRevert(KeyManagerAddress.DuplicateKey.selector);
@@ -2071,18 +2071,18 @@ contract FullTest is Test {
 
         // UPDATE OPERATOR #2 KEY AND THEN DEREGISTER
         middleware.pauseOperator(operator2);
-        vm.warp(block.timestamp + SLASHING_WINDOW + 1);
+        vm.warp(vm.getBlockTimestamp() + SLASHING_WINDOW + 1);
         middleware.updateOperatorKey(operator2, abi.encode(NEW_OPERATOR2_KEY));
-        vm.warp(block.timestamp + SLASHING_WINDOW + 1);
+        vm.warp(vm.getBlockTimestamp() + SLASHING_WINDOW + 1);
         middleware.unregisterOperator(operator2);
-        vm.warp(block.timestamp + SLASHING_WINDOW + 1);
+        vm.warp(vm.getBlockTimestamp() + SLASHING_WINDOW + 1);
 
         vm.startPrank(operator2);
         operatorNetworkOptInService.optOut(tanssi);
         operatorVaultOptInService.optOut(address(vaultsData.v2.vault));
         vm.stopPrank();
 
-        vm.warp(block.timestamp + NETWORK_EPOCH_DURATION + 1);
+        vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION + 1);
 
         vm.startPrank(owner);
         // ASSIGN OPERATOR #2 KEY TO OPERATOR #1
@@ -2122,9 +2122,9 @@ contract FullTest is Test {
         // Owner pauses and unregisters operator
         vm.startPrank(owner);
         middleware.pauseOperator(operator2);
-        vm.warp(block.timestamp + SLASHING_WINDOW + 1);
+        vm.warp(vm.getBlockTimestamp() + SLASHING_WINDOW + 1);
         middleware.unregisterOperator(operator2);
-        vm.warp(block.timestamp + SLASHING_WINDOW + 1);
+        vm.warp(vm.getBlockTimestamp() + SLASHING_WINDOW + 1);
 
         // Operator opts out
         vm.startPrank(operator2);
@@ -2307,13 +2307,13 @@ contract FullTest is Test {
         // Operator 3 has stake in vault2 (no slasher) and vault3 (instant slasher)
         vm.warp(VAULT_EPOCH_DURATION + 2);
         uint48 slashingEpoch = middleware.getCurrentEpoch();
-        vm.warp(block.timestamp + NETWORK_EPOCH_DURATION + 1);
+        vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION + 1);
 
         vm.startPrank(gateway);
         middleware.slash(slashingEpoch, OPERATOR3_KEY, SLASHING_FRACTION);
         vm.stopPrank();
 
-        vm.warp(block.timestamp + NETWORK_EPOCH_DURATION + 1);
+        vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION + 1);
         _checkStakesAfterIntantSlashing();
     }
 
@@ -2321,7 +2321,7 @@ contract FullTest is Test {
         // Operator 3 has stake in vault2 (no slasher) and vault3 (instant slasher)
         vm.warp(VAULT_EPOCH_DURATION + 2);
         uint48 slashingEpoch = middleware.getCurrentEpoch();
-        vm.warp(block.timestamp + NETWORK_EPOCH_DURATION + 1);
+        vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION + 1);
 
         vm.startPrank(gateway);
         middleware.slash(slashingEpoch, OPERATOR3_KEY, SLASHING_FRACTION);
@@ -2330,7 +2330,7 @@ contract FullTest is Test {
         // Start withdrawing BTC as soon as he finds out about the slash. It should not affect the resulting slash
         _withdrawFromVault(vaultsData.v2.vault, operator2, OPERATOR2_STAKE_V2_WBTC / 2);
 
-        vm.warp(block.timestamp + NETWORK_EPOCH_DURATION + 1);
+        vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION + 1);
         _checkStakesAfterIntantSlashing();
     }
 
@@ -2342,13 +2342,13 @@ contract FullTest is Test {
         // Start withdrawing BTC before knowing about the slash. This value is still slashable so the resulting slash should not change
         _withdrawFromVault(vaultsData.v2.vault, operator2, OPERATOR2_STAKE_V2_WBTC / 2);
 
-        vm.warp(block.timestamp + NETWORK_EPOCH_DURATION + 1);
+        vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION + 1);
 
         vm.startPrank(gateway);
         middleware.slash(slashingEpoch, OPERATOR3_KEY, SLASHING_FRACTION);
         vm.stopPrank();
 
-        vm.warp(block.timestamp + NETWORK_EPOCH_DURATION + 1);
+        vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION + 1);
         _checkStakesAfterIntantSlashing();
     }
 
@@ -2356,16 +2356,16 @@ contract FullTest is Test {
         // Operator 7 has stake in vault5 (veto slasher) only
         vm.warp(VAULT_EPOCH_DURATION + 2);
         uint48 slashingEpoch = middleware.getCurrentEpoch();
-        vm.warp(block.timestamp + NETWORK_EPOCH_DURATION + 1);
+        vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION + 1);
 
         vm.startPrank(gateway);
         middleware.slash(slashingEpoch, OPERATOR7_KEY, SLASHING_FRACTION);
         vm.stopPrank();
 
-        vm.warp(block.timestamp + VETO_DURATION);
+        vm.warp(vm.getBlockTimestamp() + VETO_DURATION);
         middleware.executeSlash(address(vaultsData.v5.vault), 0, hex"");
 
-        vm.warp(block.timestamp + NETWORK_EPOCH_DURATION + 1);
+        vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION + 1);
 
         _checkStakesAfterVetoSlashing(0, 0);
     }
@@ -2374,7 +2374,7 @@ contract FullTest is Test {
         // Operator 7 has stake in vault5 (veto slasher) only
         vm.warp(VAULT_EPOCH_DURATION + 2);
         uint48 slashingEpoch = middleware.getCurrentEpoch();
-        vm.warp(block.timestamp + NETWORK_EPOCH_DURATION + 1);
+        vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION + 1);
 
         vm.startPrank(gateway);
         middleware.slash(slashingEpoch, OPERATOR7_KEY, SLASHING_FRACTION);
@@ -2384,10 +2384,10 @@ contract FullTest is Test {
         uint256 withdrawAmount = OPERATOR7_STAKE_V5_STETH / 2;
         _withdrawFromVault(vaultsData.v5.vault, operator7, withdrawAmount);
 
-        vm.warp(block.timestamp + VETO_DURATION);
+        vm.warp(vm.getBlockTimestamp() + VETO_DURATION);
         middleware.executeSlash(address(vaultsData.v5.vault), 0, hex"");
 
-        vm.warp(block.timestamp + NETWORK_EPOCH_DURATION + 1);
+        vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION + 1);
         _checkStakesAfterVetoSlashing(withdrawAmount, 0);
     }
 
@@ -2405,10 +2405,10 @@ contract FullTest is Test {
         middleware.slash(slashingEpoch, OPERATOR7_KEY, SLASHING_FRACTION);
         vm.stopPrank();
 
-        vm.warp(block.timestamp + VETO_DURATION);
+        vm.warp(vm.getBlockTimestamp() + VETO_DURATION);
         middleware.executeSlash(address(vaultsData.v5.vault), 0, hex"");
 
-        vm.warp(block.timestamp + NETWORK_EPOCH_DURATION + 1);
+        vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION + 1);
         _checkStakesAfterVetoSlashing(withdrawAmount, 0);
     }
 
@@ -2420,17 +2420,17 @@ contract FullTest is Test {
         uint256 withdrawAmount = OPERATOR7_STAKE_V5_STETH / 2;
         _withdrawFromVault(vaultsData.v5.vault, operator7, withdrawAmount);
 
-        vm.warp(block.timestamp + NETWORK_EPOCH_DURATION + 1);
+        vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION + 1);
         uint48 slashingEpoch = middleware.getCurrentEpoch();
 
         vm.startPrank(gateway);
         middleware.slash(slashingEpoch, OPERATOR7_KEY, SLASHING_FRACTION);
         vm.stopPrank();
 
-        vm.warp(block.timestamp + VETO_DURATION);
+        vm.warp(vm.getBlockTimestamp() + VETO_DURATION);
         middleware.executeSlash(address(vaultsData.v5.vault), 0, hex"");
 
-        vm.warp(block.timestamp + NETWORK_EPOCH_DURATION + 1);
+        vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION + 1);
 
         // The withdraw is in a past epoch, so the slash is not applied to it
         uint256 operator7Vault5SlashedStake =
@@ -2460,16 +2460,16 @@ contract FullTest is Test {
         _withdrawFromVault(vaultsData.v5.vault, operator7, withdrawAmount);
 
         uint48 slashingEpoch = middleware.getCurrentEpoch();
-        vm.warp(block.timestamp + NETWORK_EPOCH_DURATION + 1);
+        vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION + 1);
 
         vm.startPrank(gateway);
         middleware.slash(slashingEpoch, OPERATOR7_KEY, SLASHING_FRACTION);
         vm.stopPrank();
 
-        vm.warp(block.timestamp + VETO_DURATION);
+        vm.warp(vm.getBlockTimestamp() + VETO_DURATION);
         middleware.executeSlash(address(vaultsData.v5.vault), 0, hex"");
 
-        vm.warp(block.timestamp + NETWORK_EPOCH_DURATION + 1);
+        vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION + 1);
         _checkStakesAfterVetoSlashing(withdrawAmount, 0);
     }
 
@@ -2481,16 +2481,16 @@ contract FullTest is Test {
         // Operator 7 has stake in vault5 (veto slasher) only
         vm.warp(VAULT_EPOCH_DURATION + 2);
         uint48 slashingEpoch = middleware.getCurrentEpoch();
-        vm.warp(block.timestamp + NETWORK_EPOCH_DURATION + 1);
+        vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION + 1);
 
         vm.startPrank(gateway);
         middleware.slash(slashingEpoch, OPERATOR7_KEY, SLASHING_FRACTION);
         vm.stopPrank();
 
-        vm.warp(block.timestamp + VETO_DURATION);
+        vm.warp(vm.getBlockTimestamp() + VETO_DURATION);
         middleware.executeSlash(address(vaultsData.v5.vault), 0, hex"");
 
-        vm.warp(block.timestamp + NETWORK_EPOCH_DURATION + 1);
+        vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION + 1);
 
         _checkStakesAfterVetoSlashing(0, staker1Stake);
     }
@@ -2503,7 +2503,7 @@ contract FullTest is Test {
         // Operator 7 has stake in vault5 (veto slasher) only
         vm.warp(VAULT_EPOCH_DURATION + 2);
         uint48 slashingEpoch = middleware.getCurrentEpoch();
-        vm.warp(block.timestamp + NETWORK_EPOCH_DURATION + 1);
+        vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION + 1);
 
         vm.startPrank(gateway);
         middleware.slash(slashingEpoch, OPERATOR7_KEY, SLASHING_FRACTION);
@@ -2513,10 +2513,10 @@ contract FullTest is Test {
         uint256 withdrawAmount = OPERATOR7_STAKE_V5_STETH / 2;
         _withdrawFromVault(vaultsData.v5.vault, operator7, withdrawAmount);
 
-        vm.warp(block.timestamp + VETO_DURATION);
+        vm.warp(vm.getBlockTimestamp() + VETO_DURATION);
         middleware.executeSlash(address(vaultsData.v5.vault), 0, hex"");
 
-        vm.warp(block.timestamp + NETWORK_EPOCH_DURATION + 1);
+        vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION + 1);
         _checkStakesAfterVetoSlashing(withdrawAmount, staker1Stake);
     }
 
@@ -2532,16 +2532,16 @@ contract FullTest is Test {
         _withdrawFromVault(vaultsData.v5.vault, operator7, withdrawAmount);
 
         uint48 slashingEpoch = middleware.getCurrentEpoch();
-        vm.warp(block.timestamp + NETWORK_EPOCH_DURATION + 1);
+        vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION + 1);
 
         vm.startPrank(gateway);
         middleware.slash(slashingEpoch, OPERATOR7_KEY, SLASHING_FRACTION);
         vm.stopPrank();
 
-        vm.warp(block.timestamp + VETO_DURATION);
+        vm.warp(vm.getBlockTimestamp() + VETO_DURATION);
         middleware.executeSlash(address(vaultsData.v5.vault), 0, hex"");
 
-        vm.warp(block.timestamp + NETWORK_EPOCH_DURATION + 1);
+        vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION + 1);
         _checkStakesAfterVetoSlashing(withdrawAmount, staker1Stake);
     }
 
@@ -2707,7 +2707,7 @@ contract FullTest is Test {
     }
 
     function testCannotRegisterSharedOverTheLimit() public {
-        vm.warp(block.timestamp + NETWORK_EPOCH_DURATION + 1);
+        vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION + 1);
         uint256 maxVaults = middleware.MAX_ACTIVE_VAULTS();
         uint256 activeSharedVaults = middlewareReader.sharedVaultsLength();
 
@@ -2738,7 +2738,7 @@ contract FullTest is Test {
             (address vault,,) = deployVault.createBaseVault(params);
             middleware.registerSharedVault(address(vault), stakerRewardsParams);
         }
-        vm.warp(block.timestamp + VAULT_EPOCH_DURATION + 1);
+        vm.warp(vm.getBlockTimestamp() + VAULT_EPOCH_DURATION + 1);
         activeSharedVaults = middlewareReader.sharedVaultsLength();
         assertLe(activeSharedVaults, maxVaults);
 
@@ -2750,7 +2750,7 @@ contract FullTest is Test {
     }
 
     function testWhenOperatorManagesToBeActiveInTooManyVaultsThenItIsIgnored() public {
-        vm.warp(block.timestamp + NETWORK_EPOCH_DURATION + 1);
+        vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION + 1);
 
         // Before everything happens, the operator 1 is already registered in a vault and has power. Once he is in too many vaults his power must become 0 even if no stake is removed.
         (, bytes memory performData) = middleware.checkUpkeep(hex"");
@@ -2807,7 +2807,7 @@ contract FullTest is Test {
             (address vault,,) = deployVault.createBaseVault(params);
             middleware.registerSharedVault(address(vault), stakerRewardsParams);
         }
-        vm.warp(block.timestamp + VAULT_EPOCH_DURATION + 1);
+        vm.warp(vm.getBlockTimestamp() + VAULT_EPOCH_DURATION + 1);
         activeSharedVaults = middlewareReader.sharedVaultsLength();
         activeOperatorVaults = middlewareReader.operatorVaultsLength(operator1);
 
@@ -2845,7 +2845,7 @@ contract FullTest is Test {
         // Distribute rewards
         uint48 eraIndex = 5;
         uint256 amountToDistribute = 100 ether;
-        vm.warp(block.timestamp + 5 * NETWORK_EPOCH_DURATION);
+        vm.warp(vm.getBlockTimestamp() + 5 * NETWORK_EPOCH_DURATION);
 
         _prepareRewardsDistribution(eraIndex, amountToDistribute);
 

--- a/test/integration/Middleware.t.sol
+++ b/test/integration/Middleware.t.sol
@@ -560,7 +560,7 @@ contract MiddlewareTest is Test {
         Middleware.ValidatorData[] memory validatorsPreviousEpoch =
             OBaseMiddlewareReader(address(middleware)).getValidatorSet(previousEpoch);
 
-        vm.warp(block.timestamp + NETWORK_EPOCH_DURATION + 2);
+        vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION + 2);
         Middleware.ValidatorData[] memory validators =
             OBaseMiddlewareReader(address(middleware)).getValidatorSet(previousEpoch);
         assertEq(validators.length, validatorsPreviousEpoch.length);
@@ -573,7 +573,7 @@ contract MiddlewareTest is Test {
     }
 
     function testUnregisterOperatorButPastVaultsAreNotShown() public {
-        vm.warp(block.timestamp + SLASHING_WINDOW + 1);
+        vm.warp(vm.getBlockTimestamp() + SLASHING_WINDOW + 1);
         uint48 previousEpoch = middleware.getCurrentEpoch();
         uint48 previousEpochStartTs = middleware.getEpochStart(previousEpoch);
 
@@ -582,7 +582,7 @@ contract MiddlewareTest is Test {
         assertEq(operatorVaults.length, 3);
 
         middleware.pauseOperator(operator2);
-        vm.warp(block.timestamp + NETWORK_EPOCH_DURATION + SLASHING_WINDOW + 1);
+        vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION + SLASHING_WINDOW + 1);
         middleware.unregisterOperator(operator2);
 
         // Get validator set for current epoch
@@ -640,7 +640,7 @@ contract MiddlewareTest is Test {
 
         vm.prank(resolver1);
         vetoSlasher.vetoSlash(0, hex"");
-        vm.warp(block.timestamp + SLASHING_WINDOW + 1);
+        vm.warp(vm.getBlockTimestamp() + SLASHING_WINDOW + 1);
         uint48 newEpoch = middleware.getCurrentEpoch();
         validators = OBaseMiddlewareReader(address(middleware)).getValidatorSet(newEpoch);
 
@@ -697,10 +697,10 @@ contract MiddlewareTest is Test {
         vm.prank(gateway);
         middleware.slash(currentEpoch, OPERATOR2_KEY, SLASHING_FRACTION);
 
-        vm.warp(block.timestamp + VETO_DURATION);
+        vm.warp(vm.getBlockTimestamp() + VETO_DURATION);
         middleware.executeSlash(address(vaultVetoed), 0, hex"");
 
-        vm.warp(block.timestamp + SLASHING_WINDOW + 1);
+        vm.warp(vm.getBlockTimestamp() + SLASHING_WINDOW + 1);
         uint48 newEpoch = middleware.getCurrentEpoch();
         validators = OBaseMiddlewareReader(address(middleware)).getValidatorSet(newEpoch);
 
@@ -726,7 +726,7 @@ contract MiddlewareTest is Test {
         vm.prank(resolver1);
         vetoSlasher.vetoSlash(0, hex"");
 
-        vm.warp(block.timestamp + SLASHING_WINDOW + 1);
+        vm.warp(vm.getBlockTimestamp() + SLASHING_WINDOW + 1);
         uint48 newEpoch = middleware.getCurrentEpoch();
         validators = OBaseMiddlewareReader(address(middleware)).getValidatorSet(newEpoch);
 
@@ -749,10 +749,10 @@ contract MiddlewareTest is Test {
         vm.prank(gateway);
         middleware.slash(currentEpoch, OPERATOR3_KEY, SLASHING_FRACTION);
 
-        vm.warp(block.timestamp + VETO_DURATION);
+        vm.warp(vm.getBlockTimestamp() + VETO_DURATION);
         middleware.executeSlash(address(vaultVetoed), 0, hex"");
 
-        vm.warp(block.timestamp + SLASHING_WINDOW + 1);
+        vm.warp(vm.getBlockTimestamp() + SLASHING_WINDOW + 1);
         uint48 newEpoch = middleware.getCurrentEpoch();
         validators = OBaseMiddlewareReader(address(middleware)).getValidatorSet(newEpoch);
 
@@ -776,7 +776,7 @@ contract MiddlewareTest is Test {
         vm.prank(gateway);
         middleware.slash(currentEpoch, OPERATOR2_KEY, SLASHING_FRACTION);
 
-        vm.warp(block.timestamp + SLASHING_WINDOW + 1);
+        vm.warp(vm.getBlockTimestamp() + SLASHING_WINDOW + 1);
         uint48 newEpoch = middleware.getCurrentEpoch();
         validators = OBaseMiddlewareReader(address(middleware)).getValidatorSet(newEpoch);
 
@@ -801,7 +801,7 @@ contract MiddlewareTest is Test {
         //! Why this slash should anyway go through if operator was paused? Shouldn't it revert?
         middleware.slash(currentEpoch, OPERATOR2_KEY, SLASHING_FRACTION);
 
-        vm.warp(block.timestamp + SLASHING_WINDOW + 1);
+        vm.warp(vm.getBlockTimestamp() + SLASHING_WINDOW + 1);
         uint48 newEpoch = middleware.getCurrentEpoch();
         validators = OBaseMiddlewareReader(address(middleware)).getValidatorSet(newEpoch);
 
@@ -832,7 +832,7 @@ contract MiddlewareTest is Test {
 
         vm.startPrank(resolver1);
         vetoSlasher.vetoSlash(0, hex"");
-        vm.warp(block.timestamp + SLASHING_WINDOW + 1);
+        vm.warp(vm.getBlockTimestamp() + SLASHING_WINDOW + 1);
         uint48 newEpoch = middleware.getCurrentEpoch();
         validators = OBaseMiddlewareReader(address(middleware)).getValidatorSet(newEpoch);
 
@@ -1009,8 +1009,9 @@ contract MiddlewareTest is Test {
         tanssiCollateral.mint(operator4, 1000 * 10 ** TANSSI_TOKEN_DECIMALS);
         tanssiCollateral.mint(operator5, 1000 * 10 ** TANSSI_TOKEN_DECIMALS);
 
-        DIAOracleMock diaOracle =
-            new DIAOracleMock(TANSSI_PAIR_SYMBOL, uint128(uint256(ORACLE_CONVERSION_TANSSI)), uint128(block.timestamp));
+        DIAOracleMock diaOracle = new DIAOracleMock(
+            TANSSI_PAIR_SYMBOL, uint128(uint256(ORACLE_CONVERSION_TANSSI)), uint128(vm.getBlockTimestamp())
+        );
 
         AggregatorV3DIAProxy tanssiCollateralOracle = new AggregatorV3DIAProxy(address(diaOracle), TANSSI_PAIR_SYMBOL);
         vm.stopPrank();
@@ -1374,7 +1375,7 @@ contract MiddlewareTest is Test {
         (bool upkeepNeeded, bytes memory performData) = middleware.checkUpkeep(hex"");
         assertEq(upkeepNeeded, false);
 
-        vm.warp(block.timestamp + NETWORK_EPOCH_DURATION + 1);
+        vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION + 1);
         (upkeepNeeded, performData) = middleware.checkUpkeep(hex"");
         assertEq(upkeepNeeded, true);
 
@@ -1657,6 +1658,63 @@ contract MiddlewareTest is Test {
         }
     }
 
+    function testUpkeepShouldHaveSameOperatorsEvenIfPaused() public {
+        vm.prank(owner);
+        middleware.setForwarder(forwarder);
+        // It's not needed, it's just for explaining and showing the flow
+        address offlineKeepers = makeAddr("offlineKeepers");
+        vm.startPrank(offlineKeepers);
+        (bool upkeepNeeded, bytes memory performData) = middleware.checkUpkeep(hex"");
+        assertEq(upkeepNeeded, false);
+
+        vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION + 1);
+        (upkeepNeeded, performData) = middleware.checkUpkeep(hex"");
+        assertEq(upkeepNeeded, true);
+
+        vm.startPrank(forwarder);
+        middleware.performUpkeep(performData);
+        uint48 epoch = middleware.getCurrentEpoch();
+
+        uint256 operator1Power = middleware.getOperatorToPower(epoch, OPERATOR_KEY);
+        uint256 operator2Power = middleware.getOperatorToPower(epoch, OPERATOR2_KEY);
+        uint256 operator3Power = middleware.getOperatorToPower(epoch, OPERATOR3_KEY);
+
+        (uint256 totalOperatorPowerAfter,) = _calculateOperatorPower(totalPowerVault, 0, 0);
+        (uint256 totalOperator2PowerAfter,) =
+            _calculateOperatorPower(totalPowerVaultSlashable, totalFullRestakePower, 0);
+        (uint256 totalOperator3PowerAfter,) =
+            _calculateOperatorPower(totalPowerVault + totalPowerVaultSlashable, totalFullRestakePower, 0);
+
+        assertEq(operator1Power, totalOperatorPowerAfter);
+        assertEq(operator2Power, totalOperator2PowerAfter);
+        assertEq(operator3Power, totalOperator3PowerAfter);
+
+        vm.startPrank(owner);
+        middleware.pauseOperator(operator);
+        console2.log("Operator paused at time: ", vm.getBlockTimestamp());
+
+        vm.warp(vm.getBlockTimestamp() + 50);
+        vm.startPrank(offlineKeepers);
+        (upkeepNeeded, performData) = middleware.checkUpkeep(hex"");
+        assertEq(upkeepNeeded, true);
+
+        address[] memory activeOperators = OBaseMiddlewareReader(address(middleware)).activeOperators();
+        assertEq(activeOperators.length, 3);
+
+        (uint8 command, bytes32[] memory sortedKeys) = abi.decode(performData, (uint8, bytes32[]));
+        assertEq(command, middleware.SEND_DATA_COMMAND());
+        assertEq(sortedKeys.length, 3);
+
+        vm.startPrank(forwarder);
+        vm.expectEmit(true, false, false, false);
+        emit IOGateway.OperatorsDataCreated(sortedKeys.length, hex"");
+        middleware.performUpkeep(performData);
+
+        (upkeepNeeded, performData) = middleware.checkUpkeep(hex"");
+        assertEq(upkeepNeeded, false);
+        assertEq(performData.length, 0);
+    }
+
     function testWhenRegisteringVaultThenStakerRewardsAreDeployed() public {
         vm.startPrank(owner);
         uint256 totalEntities = stakerRewardsFactory.totalEntities();
@@ -1764,7 +1822,7 @@ contract MiddlewareTest is Test {
             tanssi.subnetwork(0), operator3, 0
         );
 
-        vm.warp(block.timestamp + VAULT_EPOCH_DURATION + 1);
+        vm.warp(vm.getBlockTimestamp() + VAULT_EPOCH_DURATION + 1);
         vm.roll(80 + 57_235); // 57_235 is ≈ the number of blocks in 1 week
         keys = middleware.sendCurrentOperatorsKeys();
         assertEq(keys.length, 3);

--- a/test/integration/Middleware.t.sol
+++ b/test/integration/Middleware.t.sol
@@ -1691,7 +1691,8 @@ contract MiddlewareTest is Test {
 
         vm.startPrank(owner);
         middleware.pauseOperator(operator);
-        console2.log("Operator paused at time: ", vm.getBlockTimestamp());
+        vm.expectRevert(PauseableEnumerableSet.ImmutablePeriodNotPassed.selector);
+        middleware.unregisterOperator(operator);
 
         vm.warp(vm.getBlockTimestamp() + 50);
         vm.startPrank(offlineKeepers);

--- a/test/unit/Deploy.t.sol
+++ b/test/unit/Deploy.t.sol
@@ -179,7 +179,7 @@ contract DeployTest is Test {
 
         (Middleware middleware,,) = deployTanssiEcosystemDemo.ecosystemEntities();
 
-        vm.warp(block.timestamp + 12 days + 1);
+        vm.warp(vm.getBlockTimestamp() + 12 days + 1);
 
         uint48 epoch = middleware.getCurrentEpoch();
         IMiddleware.OperatorVaultPair[] memory operatorVaultPairs =

--- a/test/unit/Middleware.t.sol
+++ b/test/unit/Middleware.t.sol
@@ -2551,7 +2551,7 @@ contract MiddlewareTest is Test {
 
         vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION + 1);
         uint48 epoch = middleware.getCurrentEpoch();
-        
+
         (bool upkeepNeeded, bytes memory performData) = middleware.checkUpkeep(hex"");
         assertEq(upkeepNeeded, true);
 

--- a/test/unit/Middleware.t.sol
+++ b/test/unit/Middleware.t.sol
@@ -531,7 +531,7 @@ contract MiddlewareTest is Test {
 
         vm.warp(NETWORK_EPOCH_DURATION + 2);
         middleware.pauseOperator(operator);
-        vm.warp(block.timestamp + SLASHING_WINDOW + 1);
+        vm.warp(vm.getBlockTimestamp() + SLASHING_WINDOW + 1);
         middleware.unpauseOperator(operator);
         vm.stopPrank();
     }
@@ -710,7 +710,7 @@ contract MiddlewareTest is Test {
 
         vm.warp(NETWORK_EPOCH_DURATION + 2);
         middleware.pauseSharedVault(address(vault));
-        vm.warp(block.timestamp + SLASHING_WINDOW + 1);
+        vm.warp(vm.getBlockTimestamp() + SLASHING_WINDOW + 1);
         middleware.unpauseSharedVault(address(vault));
         vm.stopPrank();
     }
@@ -1166,8 +1166,8 @@ contract MiddlewareTest is Test {
 
         vm.startPrank(owner);
         middleware.registerOperator(operator, abi.encode(OPERATOR_KEY), address(0));
-        vm.warp(block.timestamp + NETWORK_EPOCH_DURATION + 1);
-        uint48 timestamp1 = uint48(block.timestamp);
+        vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION + 1);
+        uint48 timestamp1 = uint48(vm.getBlockTimestamp());
 
         assertEq(
             OBaseMiddlewareReader(address(middleware)).getOperatorKeyAt(operator, timestamp1), abi.encode(OPERATOR_KEY)
@@ -1180,7 +1180,9 @@ contract MiddlewareTest is Test {
         assertEq(middleware.operatorKey(operator), abi.encode(bytes32(0)));
         assertEq(middleware.operatorByKey(abi.encode(OPERATOR_KEY)), address(0));
         assertEq(
-            OBaseMiddlewareReader(address(middleware)).getOperatorKeyAt(operator, uint48(block.timestamp) + 10 days),
+            OBaseMiddlewareReader(address(middleware)).getOperatorKeyAt(
+                operator, uint48(vm.getBlockTimestamp()) + 10 days
+            ),
             abi.encode(bytes32(0))
         );
     }
@@ -2288,7 +2290,7 @@ contract MiddlewareTest is Test {
 
         vm.warp(NETWORK_EPOCH_DURATION + 2);
         bytes memory key =
-            OBaseMiddlewareReader(address(middleware)).getOperatorKeyAt(operator, uint48(block.timestamp));
+            OBaseMiddlewareReader(address(middleware)).getOperatorKeyAt(operator, uint48(vm.getBlockTimestamp()));
 
         assertEq(abi.decode(key, (bytes32)), OPERATOR_KEY);
     }
@@ -2304,7 +2306,7 @@ contract MiddlewareTest is Test {
 
         vm.warp(NETWORK_EPOCH_DURATION + 2);
         bytes memory key =
-            OBaseMiddlewareReader(address(middleware)).getOperatorKeyAt(operator, uint48(block.timestamp));
+            OBaseMiddlewareReader(address(middleware)).getOperatorKeyAt(operator, uint48(vm.getBlockTimestamp()));
 
         assertEq(abi.decode(key, (bytes32)), OPERATOR_KEY);
     }
@@ -2315,7 +2317,7 @@ contract MiddlewareTest is Test {
         vm.startPrank(owner);
         middleware.registerOperator(operator, abi.encode(PREV_OPERATOR_KEY), address(0));
 
-        uint48 activeKeyTimestamp = uint48(block.timestamp + 10);
+        uint48 activeKeyTimestamp = uint48(vm.getBlockTimestamp() + 10);
         vm.warp(activeKeyTimestamp);
 
         middleware.updateOperatorKey(operator, abi.encode(OPERATOR_KEY));
@@ -2325,9 +2327,9 @@ contract MiddlewareTest is Test {
 
         assertEq(abi.decode(key, (bytes32)), PREV_OPERATOR_KEY);
 
-        vm.warp(block.timestamp + NETWORK_EPOCH_DURATION + 2);
+        vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION + 2);
 
-        key = OBaseMiddlewareReader(address(middleware)).getOperatorKeyAt(operator, uint48(block.timestamp));
+        key = OBaseMiddlewareReader(address(middleware)).getOperatorKeyAt(operator, uint48(vm.getBlockTimestamp()));
         assertEq(abi.decode(key, (bytes32)), OPERATOR_KEY);
     }
 
@@ -2336,7 +2338,7 @@ contract MiddlewareTest is Test {
         // Don't register any key for the operator
 
         bytes memory key =
-            OBaseMiddlewareReader(address(middleware)).getOperatorKeyAt(operator, uint48(block.timestamp));
+            OBaseMiddlewareReader(address(middleware)).getOperatorKeyAt(operator, uint48(vm.getBlockTimestamp()));
 
         assertEq(abi.decode(key, (bytes32)), bytes32(0));
     }
@@ -2349,7 +2351,7 @@ contract MiddlewareTest is Test {
         vm.stopPrank();
 
         // This implies that for the future the key will not be disabled.
-        uint48 futureTimestamp = uint48(block.timestamp + 1000);
+        uint48 futureTimestamp = uint48(vm.getBlockTimestamp() + 1000);
         bytes memory key = OBaseMiddlewareReader(address(middleware)).getOperatorKeyAt(operator, futureTimestamp);
 
         assertEq(abi.decode(key, (bytes32)), OPERATOR_KEY);
@@ -2378,7 +2380,7 @@ contract MiddlewareTest is Test {
 
         vm.warp(NETWORK_EPOCH_DURATION + 2);
 
-        uint48 activeTimestamp = uint48(block.timestamp);
+        uint48 activeTimestamp = uint48(vm.getBlockTimestamp());
 
         vm.warp(vm.getBlockTimestamp() + activeTimestamp + 10);
         middleware.pauseOperator(operator);
@@ -2547,7 +2549,7 @@ contract MiddlewareTest is Test {
         vm.startPrank(operator2);
         vault.deposit(operator2, OPERATOR_STAKE);
 
-        vm.warp(block.timestamp + NETWORK_EPOCH_DURATION + 1);
+        vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION + 1);
         (bool upkeepNeeded, bytes memory performData) = middleware.checkUpkeep(hex"");
         assertEq(upkeepNeeded, true);
 
@@ -2567,7 +2569,7 @@ contract MiddlewareTest is Test {
         middleware.registerOperator(operator, abi.encode(OPERATOR_KEY), address(0));
         vm.stopPrank();
 
-        vm.warp(block.timestamp + NETWORK_EPOCH_DURATION + 1);
+        vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION + 1);
         (bool upkeepNeeded, bytes memory performData) = middleware.checkUpkeep(hex"");
         assertEq(upkeepNeeded, true);
 
@@ -2592,7 +2594,7 @@ contract MiddlewareTest is Test {
         middleware.registerOperator(operator, abi.encode(OPERATOR_KEY), address(0));
         vm.stopPrank();
 
-        vm.warp(block.timestamp + NETWORK_EPOCH_DURATION + 1);
+        vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION + 1);
         (bool upkeepNeeded, bytes memory performData) = middleware.checkUpkeep(hex"");
         assertEq(upkeepNeeded, true);
 
@@ -2615,7 +2617,7 @@ contract MiddlewareTest is Test {
         middleware.registerOperator(operator, abi.encode(OPERATOR_KEY), address(0));
         vm.stopPrank();
 
-        vm.warp(block.timestamp + NETWORK_EPOCH_DURATION + 1);
+        vm.warp(vm.getBlockTimestamp() + NETWORK_EPOCH_DURATION + 1);
         (bool upkeepNeeded, bytes memory performData) = middleware.checkUpkeep(hex"");
         assertEq(upkeepNeeded, true);
 

--- a/test/unit/Oracles.t.sol
+++ b/test/unit/Oracles.t.sol
@@ -30,8 +30,9 @@ contract MiddlewareTest is Test {
     function setUp() public {
         tanssiCollateral = new Token("TANSSI", 12);
 
-        diaOracle =
-            new DIAOracleMock(TANSSI_PAIR_SYMBOL, uint128(uint256(ORACLE_CONVERSION_TANSSI)), uint128(block.timestamp));
+        diaOracle = new DIAOracleMock(
+            TANSSI_PAIR_SYMBOL, uint128(uint256(ORACLE_CONVERSION_TANSSI)), uint128(vm.getBlockTimestamp())
+        );
 
         tanssiCollateralOracle = new AggregatorV3DIAProxy(address(diaOracle), TANSSI_PAIR_SYMBOL);
     }
@@ -39,12 +40,12 @@ contract MiddlewareTest is Test {
     function testDIAGetValueTanssiPrice() public view {
         (uint128 latestPrice, uint128 latestTimestamp) = diaOracle.getValue(TANSSI_PAIR_SYMBOL);
         assertEq(latestPrice, uint128(uint256(ORACLE_CONVERSION_TANSSI)));
-        assertEq(latestTimestamp, uint128(block.timestamp));
+        assertEq(latestTimestamp, uint128(vm.getBlockTimestamp()));
     }
 
     function testDIASetValueForeignTokenPrice() public {
         uint128 newPrice = 2 * uint128(uint256(ORACLE_CONVERSION_TANSSI));
-        uint128 newTimestamp = uint128(block.timestamp + 1000);
+        uint128 newTimestamp = uint128(vm.getBlockTimestamp() + 1000);
         diaOracle.setValue(newPrice, newTimestamp, TANSSI_PAIR_SYMBOL);
 
         (uint128 latestPrice, uint128 latestTimestamp) = diaOracle.getValue(TANSSI_PAIR_SYMBOL);
@@ -73,8 +74,8 @@ contract MiddlewareTest is Test {
 
         assertEq(roundId, 1);
         assertEq(price, int256(uint256(ORACLE_CONVERSION_TANSSI)));
-        assertEq(startedAt, block.timestamp);
-        assertEq(updatedAt, block.timestamp);
+        assertEq(startedAt, vm.getBlockTimestamp());
+        assertEq(updatedAt, vm.getBlockTimestamp());
         assertEq(answeredInRound, 1);
     }
 
@@ -84,8 +85,8 @@ contract MiddlewareTest is Test {
 
         assertEq(roundId, 1);
         assertEq(price, int256(uint256(ORACLE_CONVERSION_TANSSI)));
-        assertEq(startedAt, block.timestamp);
-        assertEq(updatedAt, block.timestamp);
+        assertEq(startedAt, vm.getBlockTimestamp());
+        assertEq(updatedAt, vm.getBlockTimestamp());
         assertEq(answeredInRound, 1);
     }
 


### PR DESCRIPTION
Operators can't change during an epoch, hence checkUpkeep always return the active at the start of epoch

https://github.com/PashovAuditGroup/Tanssi_July25_MERGED/issues/12