### PR TITLE
[M-1] Forces staker rewards init params to include a non zero admin.

### DIFF
--- a/src/contracts/rewarder/ODefaultStakerRewards.sol
+++ b/src/contracts/rewarder/ODefaultStakerRewards.sol
@@ -116,17 +116,7 @@ contract ODefaultStakerRewards is
         }
 
         if (params.defaultAdminRoleHolder == address(0)) {
-            if (params.adminFee == 0) {
-                if (params.adminFeeClaimRoleHolder == address(0)) {
-                    if (params.adminFeeSetRoleHolder != address(0)) {
-                        revert ODefaultStakerRewards__MissingRoles();
-                    }
-                } else if (params.adminFeeSetRoleHolder == address(0)) {
-                    revert ODefaultStakerRewards__MissingRoles();
-                }
-            } else if (params.adminFeeClaimRoleHolder == address(0)) {
-                revert ODefaultStakerRewards__MissingRoles();
-            }
+            revert ODefaultStakerRewards__MissingRoles();
         }
 
         __AccessControl_init();
@@ -137,9 +127,7 @@ contract ODefaultStakerRewards is
 
         i_vault = vault_;
 
-        if (params.defaultAdminRoleHolder != address(0)) {
-            _grantRole(DEFAULT_ADMIN_ROLE, params.defaultAdminRoleHolder);
-        }
+        _grantRole(DEFAULT_ADMIN_ROLE, params.defaultAdminRoleHolder);
         if (params.adminFeeClaimRoleHolder != address(0)) {
             _grantRole(ADMIN_FEE_CLAIM_ROLE, params.adminFeeClaimRoleHolder);
         }

--- a/test/unit/Rewards.t.sol
+++ b/test/unit/Rewards.t.sol
@@ -963,7 +963,7 @@ contract RewardsTest is Test {
     function testStakerRewardsFactoryConstructorNotVault() public {
         IODefaultStakerRewards.InitParams memory params = IODefaultStakerRewards.InitParams({
             adminFee: 0,
-            defaultAdminRoleHolder: address(0),
+            defaultAdminRoleHolder: owner,
             adminFeeClaimRoleHolder: address(0),
             adminFeeSetRoleHolder: address(middleware),
             implementation: stakerRewardsImplementation
@@ -979,7 +979,7 @@ contract RewardsTest is Test {
         stakerRewardsFactory.create(address(vault), params);
     }
 
-    function testStakerRewardsConstructorWithNoAdminFeeAndNoAdminFeeClaimRoleHolder() public {
+    function testStakerRewardsConstructorWithNoAdminRoleHolder() public {
         IODefaultStakerRewards.InitParams memory params = IODefaultStakerRewards.InitParams({
             adminFee: 0,
             defaultAdminRoleHolder: address(0),
@@ -995,7 +995,7 @@ contract RewardsTest is Test {
     function testStakerRewardsConstructorWithNoAdminFeeAndBothAdminRole() public {
         IODefaultStakerRewards.InitParams memory params = IODefaultStakerRewards.InitParams({
             adminFee: 0,
-            defaultAdminRoleHolder: address(0),
+            defaultAdminRoleHolder: owner,
             adminFeeClaimRoleHolder: address(middleware),
             adminFeeSetRoleHolder: address(middleware),
             implementation: stakerRewardsImplementation
@@ -1020,36 +1020,10 @@ contract RewardsTest is Test {
         stakerRewardsFactory.create(address(vault), params);
     }
 
-    function testStakerRewardsConstructorWithNoAdminFeeSetRoleHolder() public {
-        IODefaultStakerRewards.InitParams memory params = IODefaultStakerRewards.InitParams({
-            adminFee: 0,
-            defaultAdminRoleHolder: address(0),
-            adminFeeClaimRoleHolder: address(middleware),
-            adminFeeSetRoleHolder: address(0),
-            implementation: stakerRewardsImplementation
-        });
-
-        vm.expectRevert(IODefaultStakerRewards.ODefaultStakerRewards__MissingRoles.selector);
-        stakerRewardsFactory.create(address(vault), params);
-    }
-
-    function testStakerRewardsConstructorWithNoAdminFeeClaimRoleHolder() public {
-        IODefaultStakerRewards.InitParams memory params = IODefaultStakerRewards.InitParams({
-            adminFee: ADMIN_FEE,
-            defaultAdminRoleHolder: address(0),
-            adminFeeClaimRoleHolder: address(0),
-            adminFeeSetRoleHolder: address(middleware),
-            implementation: stakerRewardsImplementation
-        });
-
-        vm.expectRevert(IODefaultStakerRewards.ODefaultStakerRewards__MissingRoles.selector);
-        stakerRewardsFactory.create(address(vault), params);
-    }
-
     function testStakerRewardsConstructorWithAdminFeeClaimRoleHolder() public {
         IODefaultStakerRewards.InitParams memory params = IODefaultStakerRewards.InitParams({
             adminFee: ADMIN_FEE,
-            defaultAdminRoleHolder: address(0),
+            defaultAdminRoleHolder: owner,
             adminFeeClaimRoleHolder: address(middleware),
             adminFeeSetRoleHolder: address(middleware),
             implementation: stakerRewardsImplementation
@@ -1898,7 +1872,7 @@ contract RewardsTest is Test {
     function testStakerRewardsFactoryCreate() public {
         IODefaultStakerRewards.InitParams memory params = IODefaultStakerRewards.InitParams({
             adminFee: ADMIN_FEE,
-            defaultAdminRoleHolder: address(0),
+            defaultAdminRoleHolder: owner,
             adminFeeClaimRoleHolder: address(middleware),
             adminFeeSetRoleHolder: address(middleware),
             implementation: stakerRewardsImplementation
@@ -1953,7 +1927,7 @@ contract RewardsTest is Test {
 
         IODefaultStakerRewards.InitParams memory params = IODefaultStakerRewards.InitParams({
             adminFee: ADMIN_FEE,
-            defaultAdminRoleHolder: address(0),
+            defaultAdminRoleHolder: owner,
             adminFeeClaimRoleHolder: address(middleware),
             adminFeeSetRoleHolder: address(middleware),
             implementation: invalidImplementation


### PR DESCRIPTION
Fixes https://github.com/PashovAuditGroup/Tanssi_July25_MERGED/issues/7
All the other checks become irrelevant since the admin holder can later set roles.