### PR TITLE
[L-01] Extra memory allocation in getValidatorSet() due to pre-sized array

### DIFF
--- a/src/contracts/middleware/MiddlewareStorage.sol
+++ b/src/contracts/middleware/MiddlewareStorage.sol
@@ -163,7 +163,7 @@ abstract contract MiddlewareStorage {
      * @param operatorKey The operator key
      * @return The power of the operator
      */
-    function getOperatorToPower(uint48 epoch, bytes32 operatorKey) public view returns (uint256) {
+    function getOperatorToPowerCached(uint48 epoch, bytes32 operatorKey) public view returns (uint256) {
         StorageMiddlewareCache storage $ = _getMiddlewareStorageCache();
         return $.operatorKeyToPower[epoch][operatorKey];
     }

--- a/src/contracts/middleware/OBaseMiddlewareReader.sol
+++ b/src/contracts/middleware/OBaseMiddlewareReader.sol
@@ -684,7 +684,7 @@ contract OBaseMiddlewareReader is
             }
 
             if (key != bytes32(0)) {
-                uint256 power = getOperatorToPower(epoch, key);
+                uint256 power = getOperatorToPowerCached(epoch, key);
                 if (power == 0) {
                     power = _optmizedGetOperatorPowerAt(epochStartTs, sharedVaults, subnetwork, operator);
                 }

--- a/src/contracts/middleware/OBaseMiddlewareReader.sol
+++ b/src/contracts/middleware/OBaseMiddlewareReader.sol
@@ -678,19 +678,23 @@ contract OBaseMiddlewareReader is
         for (uint256 i; i < operatorsLength_;) {
             address operator = operators[i];
             bytes32 key = abi.decode(getOperatorKeyAt(operator, epochStartTs), (bytes32));
-            uint256 operatorPowerCached = getOperatorToPower(epoch, key);
-
-            if (operatorPowerCached != 0) {
-                validatorSet[len++] = IMiddleware.ValidatorData(operatorPowerCached, key);
-            } else {
-                uint256 power = _optmizedGetOperatorPowerAt(epochStartTs, sharedVaults, subnetwork, operator);
-                if (key != bytes32(0) && power != 0) {
-                    validatorSet[len++] = IMiddleware.ValidatorData(power, key);
-                }
-            }
 
             unchecked {
                 ++i;
+            }
+
+            if (key != bytes32(0)) {
+                uint256 power = getOperatorToPower(epoch, key);
+                if (power == 0) {
+                    power = _optmizedGetOperatorPowerAt(epochStartTs, sharedVaults, subnetwork, operator);
+                }
+
+                if (power != 0) {
+                    validatorSet[len] = IMiddleware.ValidatorData(power, key);
+                    unchecked {
+                        ++len;
+                    }
+                }
             }
         }
 

--- a/test/integration/Middleware.t.sol
+++ b/test/integration/Middleware.t.sol
@@ -1382,9 +1382,9 @@ contract MiddlewareTest is Test {
         middleware.performUpkeep(performData);
         uint48 epoch = middleware.getCurrentEpoch();
 
-        uint256 operator1Power = middleware.getOperatorToPower(epoch, OPERATOR_KEY);
-        uint256 operator2Power = middleware.getOperatorToPower(epoch, OPERATOR2_KEY);
-        uint256 operator3Power = middleware.getOperatorToPower(epoch, OPERATOR3_KEY);
+        uint256 operator1Power = middleware.getOperatorToPowerCached(epoch, OPERATOR_KEY);
+        uint256 operator2Power = middleware.getOperatorToPowerCached(epoch, OPERATOR2_KEY);
+        uint256 operator3Power = middleware.getOperatorToPowerCached(epoch, OPERATOR3_KEY);
 
         (uint256 totalOperatorPowerAfter,) = _calculateOperatorPower(totalPowerVault, 0, 0);
         (uint256 totalOperator2PowerAfter,) =


### PR DESCRIPTION
This originally aimed to apply the suggestion on https://github.com/PashovAuditGroup/Tanssi_July25_MERGED/issues/1 which was not practical, but a small possibility for improvement was found.