### PR TITLE
Returns 0 instead of reverting on on StakerRewards.claimable when there are no rewards

### DIFF
--- a/src/contracts/rewarder/ODefaultStakerRewards.sol
+++ b/src/contracts/rewarder/ODefaultStakerRewards.sol
@@ -146,15 +146,19 @@ contract ODefaultStakerRewards is
         address tokenAddress
     ) external view override returns (uint256 amount) {
         StakerRewardsStorage storage $ = _getStakerRewardsStorage();
+        uint256 activeSharesCache_ = $.activeSharesCache[epoch];
+        if (activeSharesCache_ == 0) {
+            return 0;
+        }
+
         uint256 rewardsPerEpoch = $.rewards[epoch][tokenAddress];
         uint256 claimedPerEpoch = $.stakerClaimedRewardPerEpoch[account][epoch][tokenAddress];
 
         uint48 epochTs = EpochCapture(INetworkMiddlewareService(i_networkMiddlewareService).middleware(i_network))
             .getEpochStart(epoch);
 
-        amount = IVault(i_vault).activeSharesOfAt(account, epochTs, new bytes(0)).mulDiv(
-            rewardsPerEpoch, $.activeSharesCache[epoch]
-        );
+        amount =
+            IVault(i_vault).activeSharesOfAt(account, epochTs, new bytes(0)).mulDiv(rewardsPerEpoch, activeSharesCache_);
 
         // Get the amount that is still unclaimed
         amount -= claimedPerEpoch;

--- a/test/unit/Rewards.t.sol
+++ b/test/unit/Rewards.t.sol
@@ -1085,6 +1085,12 @@ contract RewardsTest is Test {
         assertEq(claimable, AMOUNT_TO_DISTRIBUTE / 10);
     }
 
+    function testClaimableWithZeroActiveSharesCache() public view {
+        uint48 epoch = 0;
+        uint256 claimable = stakerRewards.claimable(epoch, alice, address(token));
+        assertEq(claimable, 0);
+    }
+
     function testClaimableButWithFakeTokenAddress() public {
         uint48 epoch = 0;
         uint48 epochTs = middleware.getEpochStart(epoch);


### PR DESCRIPTION
Before this change, calling claimable reverts if there are no rewards for the epoch, which is terrible UX.