### PR TITLE
Removes setVault on staker rewards, it was needed once.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.2.2] - 2025-08-15
+
+### Removed
+
+- On ODefaultStakerRewards. Removed `setVault` method.
+
 ## [1.2.1] - 2025-08-07
 
 Commit: [e87bb61b74f982344bece33d7173ce99481ee8e8](https://github.com/moondance-labs/tanssi-symbiotic/commit/e87bb61b74f982344bece33d7173ce99481ee8e8)

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -13,6 +13,13 @@ Steps to migrate:
 - <step n>
 ```
 
+## [1.2.2]
+
+## Steps to migrate:
+
+- Deploy new `ODefaultStakerRewards` contract implementation.
+- Upgrade each `ODefaultStakerRewards` to this new implementation via `upgradeToAndCall`
+
 ## [1.2.1]
 
 ## Steps to migrate:

--- a/src/contracts/rewarder/ODefaultStakerRewards.sol
+++ b/src/contracts/rewarder/ODefaultStakerRewards.sol
@@ -377,21 +377,6 @@ contract ODefaultStakerRewards is
     }
 
     /**
-     * @dev TODO: This function should be called only once and then should be upgraded to a new implementation without this function.
-     */
-    function setVault(
-        address vault_
-    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        if (vault_ == address(0)) {
-            revert ODefaultStakerRewards__InvalidAddress();
-        }
-
-        i_vault = vault_;
-
-        emit SetVault(vault_);
-    }
-
-    /**
      * @inheritdoc IODefaultStakerRewards
      */
     function adminFee() external view returns (uint256) {

--- a/test/unit/Rewards.t.sol
+++ b/test/unit/Rewards.t.sol
@@ -1699,38 +1699,6 @@ contract RewardsTest is Test {
     }
 
     //**************************************************************************************************
-    //                                      setVault
-    //**************************************************************************************************
-
-    function testSetVault() public {
-        address newVault = makeAddr("newVault");
-        vm.startPrank(address(tanssi));
-        vm.expectEmit(true, false, false, true);
-        emit IODefaultStakerRewards.SetVault(newVault);
-        stakerRewards.setVault(newVault);
-        assertEq(stakerRewards.i_vault(), newVault);
-    }
-
-    function testSetVaultButZeroAddress() public {
-        vm.startPrank(address(tanssi));
-        vm.expectRevert(IODefaultStakerRewards.ODefaultStakerRewards__InvalidAddress.selector);
-        stakerRewards.setVault(address(0));
-    }
-
-    function testSetVaultWithInvalidRole() public {
-        address newVault = makeAddr("newVault");
-        address randomUser = makeAddr("randomUser");
-        bytes32 defaultAdminRole = stakerRewards.DEFAULT_ADMIN_ROLE();
-        vm.startPrank(randomUser);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IAccessControl.AccessControlUnauthorizedAccount.selector, randomUser, defaultAdminRole
-            )
-        );
-        stakerRewards.setVault(newVault);
-    }
-
-    //**************************************************************************************************
     //                                      claimAdminFee
     //**************************************************************************************************
 


### PR DESCRIPTION
This method was needed only to upgrade to v1.2.1. It is no longer needed and it's safer to remove it.