### PR TITLE
Saves up to 5% on batch claiming staker rewards.

### DIFF
--- a/src/interfaces/rewarder/IODefaultStakerRewards.sol
+++ b/src/interfaces/rewarder/IODefaultStakerRewards.sol
@@ -50,7 +50,7 @@ interface IODefaultStakerRewards {
      * @param network address of the network
      * @param tokenAddress address of the reward token
      * @param claimer account that claimed the reward
-     * @param epoch epoch of the reward
+     * @param epochs epochs of the rewards
      * @param recipient account that received the reward
      * @param amount amount of tokens claimed
      */
@@ -58,7 +58,7 @@ interface IODefaultStakerRewards {
         address network,
         address indexed tokenAddress,
         address indexed claimer,
-        uint48 indexed epoch,
+        uint48[] epochs,
         address recipient,
         uint256 amount
     );

--- a/test/unit/Rewards.t.sol
+++ b/test/unit/Rewards.t.sol
@@ -1214,7 +1214,11 @@ contract RewardsTest is Test {
 
         vm.prank(alice);
         vm.expectEmit(true, true, true, true);
-        emit IODefaultStakerRewards.ClaimRewards(tanssi, address(token), alice, epoch, alice, AMOUNT_TO_DISTRIBUTE / 10);
+        uint48[] memory epochs = new uint48[](1);
+        epochs[0] = epoch;
+        emit IODefaultStakerRewards.ClaimRewards(
+            tanssi, address(token), alice, epochs, alice, AMOUNT_TO_DISTRIBUTE / 10
+        );
         stakerRewards.claimRewards(alice, epoch, address(token), CLAIM_REWARDS_ADDITIONAL_DATA);
 
         claimed = stakerRewards.stakerClaimedRewardPerEpoch(alice, epoch, address(token));
@@ -1239,7 +1243,11 @@ contract RewardsTest is Test {
 
         vm.prank(alice);
         vm.expectEmit(true, true, true, true);
-        emit IODefaultStakerRewards.ClaimRewards(tanssi, address(token), alice, epoch, alice, AMOUNT_TO_DISTRIBUTE / 10);
+        uint48[] memory epochs = new uint48[](1);
+        epochs[0] = epoch;
+        emit IODefaultStakerRewards.ClaimRewards(
+            tanssi, address(token), alice, epochs, alice, AMOUNT_TO_DISTRIBUTE / 10
+        );
         stakerRewards.claimRewards(alice, epoch, address(token), CLAIM_REWARDS_ADDITIONAL_DATA);
     }
 
@@ -1261,7 +1269,11 @@ contract RewardsTest is Test {
 
         vm.prank(alice);
         vm.expectEmit(true, true, true, true);
-        emit IODefaultStakerRewards.ClaimRewards(tanssi, address(token), alice, epoch, alice, AMOUNT_TO_DISTRIBUTE / 10);
+        uint48[] memory epochs = new uint48[](1);
+        epochs[0] = epoch;
+        emit IODefaultStakerRewards.ClaimRewards(
+            tanssi, address(token), alice, epochs, alice, AMOUNT_TO_DISTRIBUTE / 10
+        );
         bytes memory customData = abi.encode(epoch);
         stakerRewards.claimRewards(alice, address(token), customData);
     }
@@ -1284,7 +1296,11 @@ contract RewardsTest is Test {
 
         vm.prank(alice);
         vm.expectEmit(true, true, true, true);
-        emit IODefaultStakerRewards.ClaimRewards(tanssi, address(token), alice, epoch, alice, AMOUNT_TO_DISTRIBUTE / 10);
+        uint48[] memory epochs = new uint48[](1);
+        epochs[0] = epoch;
+        emit IODefaultStakerRewards.ClaimRewards(
+            tanssi, address(token), alice, epochs, alice, AMOUNT_TO_DISTRIBUTE / 10
+        );
         bytes memory customData = abi.encode(epoch, 2);
         stakerRewards.claimRewards(alice, address(token), customData);
     }
@@ -1343,7 +1359,11 @@ contract RewardsTest is Test {
 
         vm.prank(alice);
         vm.expectEmit(true, true, true, true);
-        emit IODefaultStakerRewards.ClaimRewards(tanssi, address(token), alice, epoch, alice, AMOUNT_TO_DISTRIBUTE / 10);
+        uint48[] memory epochs = new uint48[](1);
+        epochs[0] = epoch;
+        emit IODefaultStakerRewards.ClaimRewards(
+            tanssi, address(token), alice, epochs, alice, AMOUNT_TO_DISTRIBUTE / 10
+        );
         stakerRewards.claimRewards(alice, epoch, address(token), claimRewardsWithFakeHints);
     }
 
@@ -1391,7 +1411,9 @@ contract RewardsTest is Test {
 
         vm.prank(alice);
         vm.expectEmit(true, true, true, true);
-        emit IODefaultStakerRewards.ClaimRewards(tanssi, address(newToken), alice, epoch, alice, newTokenAmountRewards);
+        uint48[] memory epochs = new uint48[](1);
+        epochs[0] = epoch;
+        emit IODefaultStakerRewards.ClaimRewards(tanssi, address(newToken), alice, epochs, alice, newTokenAmountRewards);
         stakerRewards.claimRewards(alice, epoch, address(newToken), CLAIM_REWARDS_ADDITIONAL_DATA);
     }
 
@@ -1432,17 +1454,16 @@ contract RewardsTest is Test {
         uint256 totalGasUsed = 0;
         vm.startPrank(alice);
         vm.expectEmit(true, true, true, true);
-        emit IODefaultStakerRewards.ClaimRewards(
-            tanssi, address(newToken), alice, currentEpoch, alice, newTokenAmountRewards
-        );
+        uint48[] memory epochs = new uint48[](1);
+        epochs[0] = currentEpoch;
+        emit IODefaultStakerRewards.ClaimRewards(tanssi, address(newToken), alice, epochs, alice, newTokenAmountRewards);
         uint256 gasBefore = gasleft();
         stakerRewards.claimRewards(alice, currentEpoch, address(newToken), CLAIM_REWARDS_ADDITIONAL_DATA);
         uint256 gasAfter = gasleft();
         totalGasUsed += gasBefore - gasAfter;
         vm.expectEmit(true, true, true, true);
-        emit IODefaultStakerRewards.ClaimRewards(
-            tanssi, address(newToken), alice, currentEpoch + 1, alice, newTokenAmountRewards
-        );
+        epochs[0] = currentEpoch + 1;
+        emit IODefaultStakerRewards.ClaimRewards(tanssi, address(newToken), alice, epochs, alice, newTokenAmountRewards);
         gasBefore = gasleft();
         stakerRewards.claimRewards(alice, currentEpoch + 1, address(newToken), CLAIM_REWARDS_ADDITIONAL_DATA);
         totalGasUsed += gasBefore - gasleft();
@@ -1497,13 +1518,12 @@ contract RewardsTest is Test {
 
         vm.prank(alice);
         vm.expectEmit(true, true, true, true);
-        emit IODefaultStakerRewards.ClaimRewards(
-            tanssi, address(newToken), alice, currentEpoch, alice, newTokenAmountRewards
-        );
+        uint48[] memory epochs = new uint48[](1);
+        epochs[0] = currentEpoch;
+        emit IODefaultStakerRewards.ClaimRewards(tanssi, address(newToken), alice, epochs, alice, newTokenAmountRewards);
         vm.expectEmit(true, true, true, true);
-        emit IODefaultStakerRewards.ClaimRewards(
-            tanssi, address(newToken), alice, currentEpoch + 1, alice, newTokenAmountRewards
-        );
+        epochs[0] = currentEpoch + 1;
+        emit IODefaultStakerRewards.ClaimRewards(tanssi, address(newToken), alice, epochs, alice, newTokenAmountRewards);
         uint256 gasBefore = gasleft();
         stakerRewards.multicall(calls);
         console2.log("Gas used for multicall: ", gasBefore - gasleft());
@@ -1554,11 +1574,7 @@ contract RewardsTest is Test {
         vm.prank(alice);
         vm.expectEmit(true, true, true, true);
         emit IODefaultStakerRewards.ClaimRewards(
-            tanssi, address(newToken), alice, currentEpoch, alice, newTokenAmountRewards
-        );
-        vm.expectEmit(true, true, true, true);
-        emit IODefaultStakerRewards.ClaimRewards(
-            tanssi, address(newToken), alice, currentEpoch + 1, alice, newTokenAmountRewards
+            tanssi, address(newToken), alice, epochs, alice, newTokenAmountRewards * 2
         );
         uint256 gasBefore = gasleft();
         stakerRewards.batchClaimRewards(alice, epochs, address(newToken), hints);


### PR DESCRIPTION
The average savings by doing a single transfer with a batch of just 2 claims, is 4.2%. If on top we update the event so we only emit once, it goes up to 5.6%.

The bigger the batch, the bigger the savings.