### PR TITLE
Emits event when operator power is cached on performUpkeep.

### DIFF
--- a/src/contracts/middleware/Middleware.sol
+++ b/src/contracts/middleware/Middleware.sol
@@ -362,6 +362,8 @@ contract Middleware is
             unchecked {
                 cache.epochToCacheIndex[epoch] += validatorsDataLength;
             }
+
+            emit OperatorsPowerCached(epoch, validatorsDataLength, pendingOperatorsToCache - validatorsDataLength);
         } else {
             uint48 currentTimestamp = Time.timestamp();
             if ((currentTimestamp - $.lastTimestamp) > $.interval) {

--- a/src/interfaces/middleware/IMiddleware.sol
+++ b/src/interfaces/middleware/IMiddleware.sol
@@ -41,6 +41,14 @@ interface IMiddleware {
      */
     event GatewaySet(address indexed gateway);
 
+    /**
+     * @notice Emitted when the operators' power is cached.
+     * @param epoch The epoch number
+     * @param operatorsCached The number of operators cached
+     * @param operatorsPending The number of operators pending to be cached after the cache update
+     */
+    event OperatorsPowerCached(uint48 indexed epoch, uint256 operatorsCached, uint256 operatorsPending);
+
     // Errors
     error Middleware__GatewayNotSet();
     error Middleware__AlreadySet();

--- a/test/integration/Full.t.sol
+++ b/test/integration/Full.t.sol
@@ -1370,6 +1370,8 @@ contract FullTest is Test {
 
             vm.startPrank(forwarder);
             gasBefore = gasleft();
+            vm.expectEmit(false, false, false, true);
+            emit IMiddleware.OperatorsPowerCached(epoch, 7, 0); // 7 operators cached, 0 pending
             middleware.performUpkeep(performData);
             console2.log("Gas used to performUpkeep:", gasBefore - gasleft());
         }


### PR DESCRIPTION
This is useful for debugging live transactions and understanding the steps a check/perform upkeep is doing.